### PR TITLE
Remove vestigial "received" event, add link to "quicstream" event

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,9 +450,9 @@ interface RTCQuicTransport : RTCStatsProvider {
       <code><a>RTCQuicStream</a></code> <var>stream</var> means that an event with the
       name <var>e</var>, which does not bubble (except where otherwise stated) and is not
       cancelable (except where otherwise stated), and which uses the
-      <code><a>RTCQuicStreamEvent</a></code> interface with the <code><a href=
-      "#dom-quicstreamevent-stream">stream</a></code> attribute set to
-      <var>stream</var>, MUST be created and dispatched at the given target.</p>
+      <code><a>RTCQuicStreamEvent</a></code> interface with the
+      <code><a href="#dom-quicstreamevent-stream">stream</a></code> attribute
+      set to <var>stream</var>, MUST be created and dispatched at the given target.</p>
       <div>
         <pre class="idl">
         [ Constructor (DOMString type, RTCQuicStreamEventInit eventInitDict), Exposed=Window]

--- a/index.html
+++ b/index.html
@@ -450,9 +450,8 @@ interface RTCQuicTransport : RTCStatsProvider {
       <code><a>RTCQuicStream</a></code> <var>stream</var> means that an event with the
       name <var>e</var>, which does not bubble (except where otherwise stated) and is not
       cancelable (except where otherwise stated), and which uses the
-      <code><a>RTCQuicStreamEvent</a></code> interface with the
-      <code><a href="#dom-quicstreamevent-stream">stream</a></code> attribute
-      set to <var>stream</var>, MUST be created and dispatched at the given target.</p>
+      <code><a>RTCQuicStreamEvent</a></code> interface with the <code>stream</code>
+      attribute set to <var>stream</var>, MUST be created and dispatched at the given target.</p>
       <div>
         <pre class="idl">
         [ Constructor (DOMString type, RTCQuicStreamEventInit eventInitDict), Exposed=Window]

--- a/index.html
+++ b/index.html
@@ -1208,78 +1208,6 @@ interface RTCQuicStream {
       </figcaption>
       </figure>
     </section>
-   <section>
-      <h3><dfn>RTCQuicStreamReceivedEvent</dfn></h3>
-      <p>The <code><a href="#event-received">received</a></code> event uses the
-      <code><a>RTCQuicStreamReceivedEvent</a></code> interface.</p>
-      <p>Firing a received event named <var>e</var> means that an event with the
-      name <var>e</var>, which does not bubble (except where otherwise stated) and is not
-      cancelable (except where otherwise stated), and which uses the
-      <code><a>RTCQuicStreamReceivedEvent</a></code> interface
-      MUST be created and dispatched at the given target.</p>
-      <div>
-        <pre class="idl">
-        [ Constructor (DOMString type, RTCQuicStreamReceivedEventInit eventInitDict), Exposed=Window]
-interface RTCQuicStreamReceivedEvent : Event {
-};</pre>
-        <section>
-          <h2>Constructors</h2>
-          <dl data-link-for="RTCQuicStreamReceivedEvent" data-dfn-for="RTCQuicStreamReceivedEvent"
-          class="constructors">
-            <dt><code>RTCQuicStreamReceivedEvent</code></dt>
-            <dd>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">type</td>
-                    <td class="prmType"><code>DOMString</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>RTCQuicStreamReceivedEventInit</a></code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicStreamReceivedEvent" data-dfn-for="RTCQuicStreamReceivedvent"
-          class="attributes">
-          </dl>
-        </section>
-      </div>
-      <div>
-          <p>The <dfn><code>RTCQuicStreamReceivedEventInit</code></dfn> dictionary includes
-          information on the read configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary RTCQuicStreamReceivedEventInit : EventInit {
-};</pre>
-        <section>
-          <h2>Dictionary RTCQuicStreamReceivedEventInit Members</h2>
-          <dl data-link-for="RTCQuicStreamReceivedEventInit" data-dfn-for=
-          "RTCQuicStreamReceivedEventInit" class="dictionary-members">
-          </dl>
-        </section>
-      </div>
-   </section>
   </section>
     <section id="privacy-security">
     <h2>Privacy and Security Considerations</h2>
@@ -1363,7 +1291,7 @@ interface RTCQuicStreamReceivedEvent : Event {
           <td>The <code><a>RTCQuicTransportState</a></code> changed.</td>
         </tr>
         <tr>
-          <td><dfn><code>quicstream</code></dfn></td>
+          <td><dfn id="event-quicstream"><code>quicstream</code></dfn></td>
           <td><code><a>RTCQuicStreamEvent</a></code></td>
           <td>A new <code><a>RTCQuicStream</a></code> is dispatched to the script in
           response to the remote peer creating a QUIC stream.</td>

--- a/index.html
+++ b/index.html
@@ -1291,7 +1291,7 @@ interface RTCQuicStream {
           <td>The <code><a>RTCQuicTransportState</a></code> changed.</td>
         </tr>
         <tr>
-          <td><dfn id="event-quicstream"><code>quicstream</code></dfn></td>
+          <td><dfn><code>quicstream</code></dfn></td>
           <td><code><a>RTCQuicStreamEvent</a></code></td>
           <td>A new <code><a>RTCQuicStream</a></code> is dispatched to the script in
           response to the remote peer creating a QUIC stream.</td>

--- a/index.html
+++ b/index.html
@@ -444,9 +444,9 @@ interface RTCQuicTransport : RTCStatsProvider {
     </section>
     <section>
       <h3><dfn>RTCQuicStreamEvent</dfn></h3>
-      <p>The <code><a href="#event-quicstream">quicstream</a></code> event uses the
+      <p>The <code><a>quicstream</a></code> event uses the
       <code><a>RTCQuicStreamEvent</a></code> interface.</p>
-      <p>Firing a quicstream event named <var>e</var> with a
+      <p>Firing a <code><a>quicstream</a></code> event named <var>e</var> with a
       <code><a>RTCQuicStream</a></code> <var>stream</var> means that an event with the
       name <var>e</var>, which does not bubble (except where otherwise stated) and is not
       cancelable (except where otherwise stated), and which uses the


### PR DESCRIPTION
Cleans up missing links encountered in PR https://github.com/w3c/webrtc-quic/pull/4