### PR TITLE
RTCQuicTransport.stop() closes streams.

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             is in the future. If a certificate has expired, <a>throw</a> an <code>InvalidAccessError</code>.</li>
             <li>Let <var>quictransport</var> be a newly constructed <code><a>RTCQuicTransport</a></code> object.</li>
             <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportStreams]]</dfn> internal slot representing a
-            list of <code><a>RTCQuicStream</a></code> objects, initialized to empty.</li>
+            sequence of <code><a>RTCQuicStream</a></code> objects, initialized to empty.</li>
             <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportState]]</dfn> internal slot, initialized to
             <code>"new"</code>.</li>
             <li>Let <var>quictransport</var> have a <dfn>[[\Certificates]]</dfn> internal slot, initialized to

--- a/index.html
+++ b/index.html
@@ -42,9 +42,10 @@
     particular, the algorithms defined in this specification are intended to be
     easy to follow, and not intended to be performant.)</p>
     <p>Implementations that use ECMAScript to implement the APIs defined in
-    this specification MUST implement them in a manner consistent with the
-    ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL-1]], as
-    this specification uses that specification and terminology.</p>
+    this specification <em class="rfc2119" title="MUST">MUST</em> implement them
+    in a manner consistent with the ECMAScript Bindings defined in the Web IDL
+    specification [[!WEBIDL-1]], as this specification uses that specification
+    and terminology.</p>
   </section>
   <section>
     <h2>Terminology</h2>
@@ -144,7 +145,8 @@ interface RTCQuicTransport : RTCStatsProvider {
         <section>
           <h2>Constructors</h2>
           When the <code><a>RTCQuicTransport</a></code> constructor is invoked,
-          the user agent MUST run the following steps:
+          the user agent <em class="rfc2119" title="MUST">MUST</em> run the
+          following steps:
           <ol>
             <li>If the <code><a>RTCIceTransport</a></code> <var>transport</var>
             provided in the first argument is in the <code>closed</code>
@@ -158,6 +160,8 @@ interface RTCQuicTransport : RTCStatsProvider {
             <code>expires</code> attribute of each <code><a>RTCCertificate</a></code> object
             is in the future. If a certificate has expired, <a>throw</a> an <code>InvalidAccessError</code>.</li>
             <li>Let <var>quictransport</var> be a newly constructed <code><a>RTCQuicTransport</a></code> object.</li>
+            <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportStreams]]</dfn> internal slot representing a
+            list of <code><a>RTCQuicStream</a></code> objects, initialized to empty.</li>
             <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportState]]</dfn> internal slot, initialized to
             <code>"new"</code>.</li>
             <li>Let <var>quictransport</var> have a <dfn>[[\Certificates]]</dfn> internal slot, initialized to
@@ -213,8 +217,9 @@ interface RTCQuicTransport : RTCStatsProvider {
             <dt><dfn><code>state</code></dfn> of type <span class=
             "idlAttrType"><a>RTCQuicTransportState</a></span>, readonly</dt>
             <dd>
-              <p>The current state of the QUIC transport. On getting, it MUST return
-              the value of the <a>[[\QuicTransportState]]</a> internal slot.</p>
+              <p>The current state of the QUIC transport. On getting, it
+              <em class="rfc2119" title="MUST">MUST</em> return the value
+              of the <a>[[\QuicTransportState]]</a> internal slot.</p>
             </dd>
             <dt><dfn><code>onstatechange</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
@@ -237,7 +242,8 @@ interface RTCQuicTransport : RTCStatsProvider {
             <dd>
               <p>This event handler, of event handler event type <code><a>quicstream</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when a remote
-              <code><a>RTCQuicStream</a></code> is created.</p>
+              <code><a>RTCQuicStream</a></code> is created.
+              </p>
             </dd>
           </dl>
         </section>
@@ -347,8 +353,25 @@ interface RTCQuicTransport : RTCStatsProvider {
             <dt><dfn><code>stop</code></dfn></dt>
             <dd>
               <p>Stops and closes the <code><a>RTCQuicTransport</a></code> object.
-              Calling <code>stop()</code> when <code>state</code> is <code>closed</code>
-              has no effect.</p>
+              This triggers an "Immediate Close," as described in [[QUIC-TRANSPORT]] section 6.13.3.
+              <p>When <code>stop</code> is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
+              run the following steps:</p>
+              <ol>
+                <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>
+                on which <code>stop</code> is invoked.</li>
+                <li>If <var>transport</var>'s <a>[[\QuicTransportState]]</a> is <code>closed</code>
+                then abort these steps.</li>
+                <li>Set <var>transport</var>'s <a>[[\QuicTransportState]]</a> to
+                <code>closed</code>.</li>
+                <li>Run the following steps for each <code><a>RTCQuicStream</a></code> <var>stream</var>
+                in <var>transport</var>'s <a>[[\QuicTransportStreams]]</a> internal slot:</li>
+                <ol>
+                  <li> Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> internal slot to <code>closed</code></li>
+                  <li> Set <var>stream</var>'s <a>[[\Readable]]</a> internal slot to <code>false</code></li>
+                  <li> Set <var>stream</var>'s <a>[[\Writable]]</a> internal slot to <code>false</code></li>
+                </ol>
+                <li>Start the "Immediate Close" procedure by sending a closing frame.</li>
+              </ol>
               <div>
                 <em>No parameters.</em>
               </div>
@@ -362,8 +385,9 @@ interface RTCQuicTransport : RTCStatsProvider {
               Since [[QUIC-TRANSPORT]] only defines reliable QUIC streams,
               <code>createStream</code> only supports creation of reliable
               streams.</p>
-              <p>When <code>createStream</code> is called, the user agent MUST run the
-              following steps:</p>
+              <p>When <code>createStream</code> is called, the user agent
+              <em class="rfc2119" title="MUST">MUST</em> run the following
+              steps:</p>
               <ol>
                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>
                 on which <code>createStream</code> is invoked.</li>
@@ -404,6 +428,10 @@ interface RTCQuicTransport : RTCStatsProvider {
                 <li>
                   <p>Let <var>stream</var> have a <dfn>[[\ReadBufferedAmount]]</dfn> internal
                   slot initialized to zero.</p>
+                </li>
+                <li>
+                  <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
+                  internal slot. </p>
                 </li>
                 <li>
                   <p>Return <var>stream</var> and continue the following steps
@@ -464,7 +492,8 @@ interface RTCQuicTransport : RTCStatsProvider {
       name <var>e</var>, which does not bubble (except where otherwise stated) and is not
       cancelable (except where otherwise stated), and which uses the
       <code><a>RTCQuicStreamEvent</a></code> interface with the <code>stream</code>
-      attribute set to <var>stream</var>, MUST be created and dispatched at the given target.</p>
+      attribute set to <var>stream</var>, <em class="rfc2119" title="MUST">MUST</em>
+      be created and dispatched at the given target.</p>
       <div>
         <pre class="idl">
         [ Constructor (DOMString type, RTCQuicStreamEventInit eventInitDict), Exposed=Window]
@@ -662,9 +691,17 @@ interface RTCQuicStreamEvent : Event {
               "idl-def-RTCQuicTransportState.closed">closed</code></dfn></td>
               <td>
                 <p>The QUIC connection has been closed intentionally via a call to
-                <code>stop()</code> or receipt of a close_notify alert. Calling
-                <code>transport.stop()</code> will also result in a transition to the
-                <code>closed</code> state.</p>
+                <code>stop()</code> or receipt of a closing frame as described in
+                [[QUIC-TRANSPORT]] section 6.13.3. When receiving a closing frame
+                the user agent <em class="rfc2119" title="MUST">MUST</em> run the
+                following steps following steps for each <code><a>RTCQuicStream</a></code>
+                <var>stream</var> in <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
+                internal slot:</p>
+                <ol>
+                  <li> Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> internal slot to <code>closed</code></li>
+                  <li> Set <var>stream</var>'s <a>[[\Readable]]</a> internal slot to <code>false</code></li>
+                  <li> Set <var>stream</var>'s <a>[[\Writable]]</a> internal slot to <code>false</code></li>
+                </ol>
               </td>
             </tr>
             <tr>
@@ -865,7 +902,7 @@ interface RTCQuicStream {
             <dt><dfn><code>write</code></dfn></dt>
             <dd>
               <p>When the <code>write</code> method is called, the <a>user agent</a>
-              MUST run the following steps:</p>
+              <em class="rfc2119" title="MUST">MUST</em> run the following steps:</p>
               <ol>
                <li>Let <var>data</var> be the first argument.</li>
                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
@@ -985,7 +1022,8 @@ interface RTCQuicStream {
               <code>InvalidStateError</code> if the <var>stream</var>'s
               <a>[[\Readable]]</a> slot transitions from true to false and the promise
               isn't <a>settled</a>. When the <code>waitForReadable</code> method is
-              called, the <a>user agent</a> MUST run the following steps:</p>
+              called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em>
+              run the following steps:</p>
               <ol>
                 <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
                 on which <code>waitForReadable</code> is invoked.</li>
@@ -1045,7 +1083,8 @@ interface RTCQuicStream {
               be <a>rejected</a> with a newly created <code>InvalidStateError</code> if the
               <var>stream</var>'s <a>[[\Writable]]</a> slot transitions from true to false
               and the promise isn't <a>settled</a>. When the <code>waitForWritable</code> method
-              is called, the <a>user agent</a> MUST run the following steps:</p>
+              is called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em> run
+              the following steps:</p>
               <ol>
                 <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
                 object on which <code>waitForWritable</code> was invoked.</li>
@@ -1107,7 +1146,8 @@ interface RTCQuicStream {
               internal slot, which represents the target number of bytes in the
               <code><a>RTCQuicStream</a></code>'s receive buffer.
               When the <code>setTargetReadBufferedAmount</code> method is called,
-              the <a>user agent</a> MUST run the following steps:</p>
+              the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em> run the
+              following steps:</p>
               <ol>
                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
                on which <code>setTargetReadBufferedAmount</code> is invoked.</li>
@@ -1341,7 +1381,10 @@ interface RTCQuicStream {
           <td><dfn><code>quicstream</code></dfn></td>
           <td><code><a>RTCQuicStreamEvent</a></code></td>
           <td>A new <code><a>RTCQuicStream</a></code> is dispatched to the script in
-          response to the remote peer creating a QUIC stream.</td>
+          response to the remote peer creating a QUIC stream. Prior to
+          <code><a>quicstream</a></code> firing, the <code><a>RTCQuicStream</a></code>
+          is added to <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
+          internal slot.</td>
         </tr>
       </tbody>
     </table>

--- a/index.html
+++ b/index.html
@@ -391,13 +391,9 @@ interface RTCQuicTransport : RTCStatsProvider {
                 then abort these steps.</li>
                 <li>Set <var>transport</var>'s <a>[[\QuicTransportState]]</a> to
                 <code>closed</code>.</li>
-                <li>Run the following steps for each <code><a>RTCQuicStream</a></code> <var>stream</var>
-                in <var>transport</var>'s <a>[[\QuicTransportStreams]]</a> internal slot:</li>
-                <ol>
-                  <li> Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> internal slot to <code>closed</code></li>
-                  <li> Set <var>stream</var>'s <a>[[\Readable]]</a> internal slot to <code>false</code></li>
-                  <li> Set <var>stream</var>'s <a>[[\Writable]]</a> internal slot to <code>false</code></li>
-                </ol>
+                <li>Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> slot to <code>closed</code>
+                for each <code><a>RTCQuicStream</a></code> <var>stream</var> in <var>transport</var>'s
+                <a>[[\QuicTransportStreams]]</a> slot.</li>
                 <li>Start the "Immediate Close" procedure by sending a closing frame.</li>
               </ol>
               <div>
@@ -721,15 +717,11 @@ interface RTCQuicStreamEvent : Event {
                 <p>The QUIC connection has been closed intentionally via a call to
                 <code>stop()</code> or receipt of a closing frame as described in
                 [[QUIC-TRANSPORT]] section 6.13.3. When receiving a closing frame
-                the user agent <em class="rfc2119" title="MUST">MUST</em> run the
-                following steps following steps for each <code><a>RTCQuicStream</a></code>
+                the user agent <em class="rfc2119" title="MUST">MUST</em> set
+                the <var>stream</var>'s <a>[[\QuicStreamState]]</a> slot to
+                <code>closed</code> for each <code><a>RTCQuicStream</a></code>
                 <var>stream</var> in <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
-                internal slot:</p>
-                <ol>
-                  <li> Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> internal slot to <code>closed</code></li>
-                  <li> Set <var>stream</var>'s <a>[[\Readable]]</a> internal slot to <code>false</code></li>
-                  <li> Set <var>stream</var>'s <a>[[\Writable]]</a> internal slot to <code>false</code></li>
-                </ol>
+                internal slot.</p>
               </td>
             </tr>
             <tr>
@@ -1022,8 +1014,6 @@ interface RTCQuicStream {
                 and abort these steps.</li>
                 <li>If <var>stream</var>'s  <a>[[\QuicStreamState]]</a> slot is <code>closed</code>,
                 then abort these steps.</li>
-                <li>Set <var>stream</var>'s <a>[[\Writable]]</a> and <a>[[\Readable]]</a>
-                slots to <code>false</code>.</li>
                 <li>Set <var>stream</var>'s <a>[[\QuicStreamState]]</a> slot to
                 <code>closed</code>.</li>
                 <li>If the closing procedure has not started yet, start it by sending a RST_STREAM
@@ -1298,9 +1288,17 @@ interface RTCQuicStream {
                      and <var>stream</var> has <a>finished reading</a>.
                      </li>
                   </ol>
-                <p>On transitioning to the <code>closed</code> state, <var>stream</var>'s
-                <a>[[\Readable]]</a> and <a>[[\Writable]]</a> slots are set to
-                <code>false</code>.</p>
+                <p>On transitioning to the <code>closed</code> state, the user agent
+                <em class="rfc2119" title="MUST">MUST</em> run the following steps:</p>
+                  <ol>
+                    <li><a>[[\Readable]]</a> and <a>[[\Writable]]</a> slots are set to
+                    <code>false</code>.</li>
+                    <li>The <var>stream</var>'s read and write buffers are cleared.</li>
+                    <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                    which the <var>stream</var> was created from.
+                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                    <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                  </ol>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
This adds a [[QuicTransportStreams]] slot. With the quicstream event or createStream(), a stream is added to this slot. When stop() is called or a receipt of a closing frame as specified in [6.13.3](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#rfc.section.6.13.3), all stream's [[Readable]] and [[Writable]] states go to false, and their state goes to closed.

Side note: I also updated places to use <em class="rfc2119" title="MUST">MUST</em> instead of MUST where this wasn't used.