### PR TITLE
Large change refactoring unidirectional streams.

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,8 @@ interface RTCQuicTransport : RTCStatsProvider {
               <p>This event handler, of event handler event type
               <code><a>newreceivestreamwithdata</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
-              from a newly created remote <code><a>RTCQuicSendStream</a></code>.
+              from a newly created remote <code><a>RTCQuicSendStream</a></code> for the
+              first time.
               </p>
             </dd>
             <dt><dfn><code>onnewbidirectionalstreamwithdata</code></dfn> of type <span class=
@@ -283,7 +284,8 @@ interface RTCQuicTransport : RTCStatsProvider {
               <p>This event handler, of event handler event type
               <code><a>newbidirectionalstreamwithdata</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when when data is received
-              from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code>.
+              from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
+              first time.
               </p>
             </dd>
           </dl>
@@ -540,7 +542,7 @@ interface RTCQuicTransport : RTCStatsProvider {
         <pre class="idl">
         [ Constructor (DOMString type, NewReceiveStreamWithDataEventInit eventInitDict), Exposed=Window]
 interface NewReceiveStreamWithDataEvent : Event {
-    readonly        attribute RTCQuicReceiveStream receiveStream;
+    readonly        attribute RTCQuicReceiveStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -584,10 +586,10 @@ interface NewReceiveStreamWithDataEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="NewReceiveStreamWithDataEvent" data-dfn-for="NewReceiveStreamWithDataEvent"
           class="attributes">
-            <dt><code>receiveStream</code> of type <span class=
+            <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicReceiveStream</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-receivequicstreamevent-stream"><code>receiveStream</code></dfn>
+              <p>The <dfn id="dom-receivequicstreamevent-stream"><code>stream</code></dfn>
               attribute represents the <code><a>RTCQuicReceiveStream</a></code> object
               associated with the event.</p>
             </dd>
@@ -598,13 +600,13 @@ interface NewReceiveStreamWithDataEvent : Event {
           <p>The <dfn><code>NewReceiveStreamWithDataEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
         <pre class="idl">dictionary NewReceiveStreamWithDataEventInit : EventInit {
-             RTCQuicReceiveStream receiveStream;
+             RTCQuicReceiveStream stream;
 };</pre>
         <section>
           <h2>Dictionary NewReceiveStreamWithDataEventInit Members</h2>
           <dl data-link-for="NewReceiveStreamWithDataEventInit" data-dfn-for=
           "NewReceiveStreamWithDataEventInit" class="dictionary-members">
-            <dt><dfn><code>receiveStream</code></dfn> of type <span class=
+            <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicReceiveStream</a></span></dt>
             <dd>
               <p>The <code><a>RTCQuicReceiveStream</a></code> object associated with the
@@ -622,7 +624,7 @@ interface NewReceiveStreamWithDataEvent : Event {
         <pre class="idl">
         [ Constructor (DOMString type, NewBidirectionalStreamWithDataEventInit eventInitDict), Exposed=Window]
 interface NewBidirectionalStreamWithDataEvent : Event {
-    readonly        attribute RTCQuicBidirectionalStream bidirectionalStream;
+    readonly        attribute RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -666,10 +668,10 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           <h2>Attributes</h2>
           <dl data-link-for="NewBidirectionalStreamWithDataEvent" data-dfn-for="NewBidirectionalStreamWithDataEvent"
           class="attributes">
-            <dt><code>bidirectionalStream</code> of type <span class=
+            <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicBidirectionalStream</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-bidirectionalquicstreamevent-stream"><code>bidirectionalStream</code></dfn>
+              <p>The <dfn id="dom-bidirectionalquicstreamevent-stream"><code>stream</code></dfn>
               attribute represents the <code><a>RTCQuicBidirectionalStream</a></code> object
               associated with the event.</p>
             </dd>
@@ -680,13 +682,13 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           <p>The <dfn><code>NewBidirectionalStreamWithDataEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
         <pre class="idl">dictionary NewBidirectionalStreamWithDataEventInit : EventInit {
-             RTCQuicBidirectionalStream bidirectionalStream;
+             RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
           <h2>Dictionary NewBidirectionalStreamWithDataEventInit Members</h2>
           <dl data-link-for="NewBidirectionalStreamWithDataEventInit" data-dfn-for=
           "NewBidirectionalStreamWithDataEventInit" class="dictionary-members">
-            <dt><dfn><code>bidirectionalStream</code></dfn> of type <span class=
+            <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicBidirectionalStream</a></span></dt>
             <dd>
               <p>The <code><a>RTCQuicBidirectionalStream</a></code> object associated with the
@@ -900,7 +902,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
             readonly attribute unsigned long writeBufferedAmount;
             readonly attribute Promise&lt;RTCQuicStreamAbortInfo&gt; writingAborted;
             void write (RTCQuicStreamWriteParameters data);
-            void abortWriting (RTCQuicStreamAbortInfo errorInfo);
+            void abortWriting (RTCQuicStreamAbortInfo abortInfo);
             Promise&lt;void&gt; waitForWriteBufferedAmountBelow(unsigned long threshold);
         };
         </pre>
@@ -1043,9 +1045,9 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 which the <var>stream</var> was created from.
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
                 <a>[[\QuicTransportStreams]]</a> internal slot.</li>
-                <li>Let <var>errorInfo</var> be the first argument.</li>
+                <li>Let <var>abortInfo</var> be the first argument.</li>
                 <li>Start the closing procedure by sending a RST_STREAM frame with its error
-                code set to the value of <var>errorInfo</var>.errorCode.</li>
+                code set to the value of <var>abortInfo</var>.errorCode.</li>
               </ol>
               <table class="parameters">
                 <tbody>
@@ -1057,7 +1059,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                     <th>Description</th>
                   </tr>
                   <tr>
-                    <td class="prmName">errorInfo</td>
+                    <td class="prmName">abortInfo</td>
                     <td class="prmType"><code>RTCQuicStreamAbortInfo</code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
@@ -1134,7 +1136,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
             readonly attribute unsigned long readableAmount;
             readonly attribute Promise&lt;RTCQuicStreamAbortInfo&gt; readingAborted;
             RTCQuicStreamReadResult readInto (Uint8Array data);
-            void abortReading (RTCQuicStreamAbortInfo errorInfo);
+            void abortReading (RTCQuicStreamAbortInfo abortInfo);
         };
         </pre>
         <section>
@@ -1217,12 +1219,12 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                <li>Let <var>result</var> be the <code><a>RTCQuicStreamReadResult</a></code>
                to be returned.</li>
                <li>If <var>stream</var> has <a>finished reading</a>, return
-               <var>result</var> with <code>bytesRead</code> set to 0 and <code>finished</code> set to
+               <var>result</var> with <code>amount</code> set to 0 and <code>finished</code> set to
                <code>true</code> and abort these steps.</li>
                <li>Transfer data from the read buffer into <var>data</var>.</li>
                <li>Decrease the value of <var>stream</var>'s <a>[[\ReadableAmount]]</a>
                slot by the length of <var>data</var> in bytes.</li>
-               <li>Set <var>result</var>'s <code>bytesRead</code> to the size of
+               <li>Set <var>result</var>'s <code>amount</code> to the size of
                <var>data</var> in bytes.</li>
                <li>If the <var>data</var> includes up to the FIN bit being read, then
                run the following steps:</li>
@@ -1280,9 +1282,9 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 which the <var>stream</var> was created from.
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
                 <a>[[\QuicTransportStreams]]</a> internal slot.</li>
-                <li>Let <var>errorInfo</var> be the first argument.</li>
+                <li>Let <var>abortInfo</var> be the first argument.</li>
                 <li>Start the closing procedure by sending a STOP_SENDING frame with its error
-                code set to the value of <var>errorInfo</var>.errorCode.</li>
+                code set to the value of <var>abortInfo</var>.errorCode.</li>
               </ol>
               <table class="parameters">
                 <tbody>
@@ -1294,7 +1296,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                     <th>Description</th>
                   </tr>
                   <tr>
-                    <td class="prmName">errorInfo</td>
+                    <td class="prmName">abortInfo</td>
                     <td class="prmType"><code>RTCQuicStreamAbortInfo</code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
@@ -1371,27 +1373,25 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       </section>
       </div>
     </section>
-    <section id="rtcquicbidirectionalstream-interface-definition*">
-      <h3>Interface <dfn>RTCQuicBidirectionalStream</dfn></h3>
+    <section id="rtcquicstream-interface-definition*">
+      <h3>Interface <dfn>RTCQuicStream</dfn></h3>
       <div>
         <pre class="idl">
         [ Exposed=Window ]
-        interface RTCQuicBidirectionalStream {
+        interface RTCQuicStream {
             readonly attribute unsigned long long streamId;
             readonly attribute RTCQuicTransport transport;
         };
-        RTCQuicBidirectionalStream includes RTCQuicWritableStream;
-        RTCQuicBidirectionalStream includes RTCQuicReadableStream;
         </pre>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicBidirectionalStream" data-dfn-for="RTCQuicBidirectionalStream" class=
+          <dl data-link-for="RTCQuicStream" data-dfn-for="RTCQuicStream" class=
           "attributes">
             <dt><dfn><code>streamId</code></dfn> of type <span class=
             "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
             <dd>
               <p>The readonly attribute referring to the ID of the
-              <code><a>RTCQuicBidirectionalStream</a></code> object.</p>
+              <code><a>RTCQuicStream</a></code> object.</p>
             </dd>
             <dt><dfn><code>transport</code></dfn> of type <span class=
             "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
@@ -1400,6 +1400,18 @@ interface NewBidirectionalStreamWithDataEvent : Event {
             </dd>
           </dl>
        </section>
+      </div>
+    </section>
+    <section id="rtcquicbidirectionalstream-interface-definition*">
+      <h3>Interface <dfn>RTCQuicBidirectionalStream</dfn></h3>
+      <div>
+        <pre class="idl">
+        [ Exposed=Window ]
+        interface RTCQuicBidirectionalStream : RTCQuicStream {
+        };
+        RTCQuicBidirectionalStream includes RTCQuicWritableStream;
+        RTCQuicBidirectionalStream includes RTCQuicReadableStream;
+        </pre>
       </div>
     </section>
     <section id="rtcquicsendstream-interface-definition*">
@@ -1407,29 +1419,10 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       <div>
         <pre class="idl">
         [ Exposed=Window ]
-        interface RTCQuicSendStream {
-            readonly attribute unsigned long long streamId;
-            readonly attribute RTCQuicTransport transport;
+        interface RTCQuicSendStream : RTCQuicStream {
         };
         RTCQuicSendStream includes RTCQuicWritableStream;
         </pre>
-        <section>
-          <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicSendStream" data-dfn-for="RTCQuicSendStream" class=
-          "attributes">
-            <dt><dfn><code>streamId</code></dfn> of type <span class=
-            "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
-            <dd>
-              <p>The readonly attribute referring to the ID of the
-              <code><a>RTCQuicSendStream</a></code> object.</p>
-            </dd>
-            <dt><dfn><code>transport</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
-            <dd>
-              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
-            </dd>
-          </dl>
-       </section>
       </div>
     </section>
     <section id="rtcquicreceivestream-interface-definition*">
@@ -1437,29 +1430,10 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       <div>
         <pre class="idl">
         [ Exposed=Window ]
-        interface RTCQuicReceiveStream {
-            readonly attribute unsigned long long streamId;
-            readonly attribute RTCQuicTransport transport;
+        interface RTCQuicReceiveStream : RTCQuicStream {
         };
         RTCQuicReceiveStream includes RTCQuicReadableStream;
         </pre>
-        <section>
-          <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicReceiveStream" data-dfn-for="RTCQuicReceiveStream" class=
-          "attributes">
-            <dt><dfn><code>streamId</code></dfn> of type <span class=
-            "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
-            <dd>
-              <p>The readonly attribute referring to the ID of the
-              <code><a>RTCQuicReadableStream</a></code> object.</p>
-            </dd>
-            <dt><dfn><code>transport</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
-            <dd>
-              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
-            </dd>
-          </dl>
-       </section>
       </div>
     </section>
     <section id="rtcquicstreamwriteparameters*">
@@ -1497,7 +1471,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       relating to the result returned from <code>readInto</code>.</p>
       <div>
         <pre class="idl">dictionary RTCQuicStreamReadResult {
-             unsigned long bytesRead;
+             unsigned long amount;
              boolean finished = false;
         };
         </pre>
@@ -1505,7 +1479,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           <h2>Dictionary <a class="idlType">RTCQuicStreamReadResult</a> Members</h2>
           <dl data-link-for="RTCQuicStreamReadResult" data-dfn-for="RTCQuicStreamReadResult" class=
           "dictionary-members">
-            <dt><dfn><code>bytesRead</code></dfn> of type <span class=
+            <dt><dfn><code>amount</code></dfn> of type <span class=
             "idlMemberType"><a>unsigned long</a></span>.</dt>
             <dd>
               <p>The amount of data read in bytes.</p>

--- a/index.html
+++ b/index.html
@@ -142,8 +142,8 @@ interface RTCQuicTransport : RTCStatsProvider {
     RTCQuicSendStream                  createSendStream ();
                     attribute EventHandler             onstatechange;
                     attribute EventHandler             onerror;
-                    attribute EventHandler             onnewreceivestreamwithdata;
-                    attribute EventHandler             onnewbidirectionalstreamwithdata;
+                    attribute EventHandler             onreceivestreamwithdata;
+                    attribute EventHandler             onbidirectionalstreamwithdata;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -272,21 +272,21 @@ interface RTCQuicTransport : RTCStatsProvider {
               "SHOULD">SHOULD</em> include QUIC error information in
               <var>error.message</var> (defined in [[!HTML51]] Section 7.1.3.8.2).</p>
             </dd>
-            <dt><dfn><code>onnewreceivestreamwithdata</code></dfn> of type <span class=
+            <dt><dfn><code>onreceivestreamwithdata</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>newreceivestreamwithdata</a></code>,
+              <code><a>receivestreamwithdata</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
               from a newly created remote <code><a>RTCQuicSendStream</a></code> for the
               first time.
               </p>
             </dd>
-            <dt><dfn><code>onnewbidirectionalstreamwithdata</code></dfn> of type <span class=
+            <dt><dfn><code>onbidirectionalstreamwithdata</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>newbidirectionalstreamwithdata</a></code>,
+              <code><a>bidirectionalstreamwithdata</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.
@@ -543,20 +543,20 @@ interface RTCQuicTransport : RTCStatsProvider {
       </div>
     </section>
     <section>
-      <h3><dfn>NewReceiveStreamWithDataEvent</dfn></h3>
-      <p>The <code><a>newreceivestreamwithdata</a></code> event uses the
-      <code><a>NewReceiveStreamWithDataEvent</a></code> interface.</p>
+      <h3><dfn>ReceiveStreamWithDataEvent</dfn></h3>
+      <p>The <code><a>receivestreamwithdata</a></code> event uses the
+      <code><a>ReceiveStreamWithDataEvent</a></code> interface.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, NewReceiveStreamWithDataEventInit eventInitDict), Exposed=Window]
-interface NewReceiveStreamWithDataEvent : Event {
+        [ Constructor (DOMString type, ReceiveStreamWithDataEventInit eventInitDict), Exposed=Window]
+interface ReceiveStreamWithDataEvent : Event {
     readonly        attribute RTCQuicReceiveStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="NewReceiveStreamWithDataEvent" data-dfn-for="NewReceiveStreamWithDataEvent"
+          <dl data-link-for="ReceiveStreamWithDataEvent" data-dfn-for="ReceiveStreamWithDataEvent"
           class="constructors">
-            <dt><code>NewReceiveStreamWithDataEvent</code></dt>
+            <dt><code>ReceiveStreamWithDataEvent</code></dt>
             <dd>
               <table class="parameters">
                 <tbody>
@@ -578,7 +578,7 @@ interface NewReceiveStreamWithDataEvent : Event {
                   </tr>
                   <tr>
                     <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>NewReceiveStreamWithDataEventInit</a></code></td>
+                    <td class="prmType"><code><a>ReceiveStreamWithDataEventInit</a></code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -592,7 +592,7 @@ interface NewReceiveStreamWithDataEvent : Event {
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="NewReceiveStreamWithDataEvent" data-dfn-for="NewReceiveStreamWithDataEvent"
+          <dl data-link-for="ReceiveStreamWithDataEvent" data-dfn-for="ReceiveStreamWithDataEvent"
           class="attributes">
             <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicReceiveStream</a></span>, readonly</dt>
@@ -605,15 +605,15 @@ interface NewReceiveStreamWithDataEvent : Event {
         </section>
       </div>
       <div>
-          <p>The <dfn><code>NewReceiveStreamWithDataEventInit</code></dfn> dictionary includes
+          <p>The <dfn><code>ReceiveStreamWithDataEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary NewReceiveStreamWithDataEventInit : EventInit {
+        <pre class="idl">dictionary ReceiveStreamWithDataEventInit : EventInit {
              RTCQuicReceiveStream stream;
 };</pre>
         <section>
-          <h2>Dictionary NewReceiveStreamWithDataEventInit Members</h2>
-          <dl data-link-for="NewReceiveStreamWithDataEventInit" data-dfn-for=
-          "NewReceiveStreamWithDataEventInit" class="dictionary-members">
+          <h2>Dictionary ReceiveStreamWithDataEventInit Members</h2>
+          <dl data-link-for="ReceiveStreamWithDataEventInit" data-dfn-for=
+          "ReceiveStreamWithDataEventInit" class="dictionary-members">
             <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicReceiveStream</a></span></dt>
             <dd>
@@ -625,20 +625,20 @@ interface NewReceiveStreamWithDataEvent : Event {
       </div>
     </section>
     <section>
-      <h3><dfn>NewBidirectionalStreamWithDataEvent</dfn></h3>
-      <p>The <code><a>newbidirectionalstreamwithdata</a></code> event uses the
-      <code><a>NewBidirectionalStreamWithDataEvent</a></code> interface.</p>
+      <h3><dfn>BidirectionalStreamWithDataEvent</dfn></h3>
+      <p>The <code><a>bidirectionalstreamwithdata</a></code> event uses the
+      <code><a>BidirectionalStreamWithDataEvent</a></code> interface.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, NewBidirectionalStreamWithDataEventInit eventInitDict), Exposed=Window]
-interface NewBidirectionalStreamWithDataEvent : Event {
+        [ Constructor (DOMString type, BidirectionalStreamWithDataEventInit eventInitDict), Exposed=Window]
+interface BidirectionalStreamWithDataEvent : Event {
     readonly        attribute RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="NewBidirectionalStreamWithDataEvent" data-dfn-for="NewBidirectionalStreamWithDataEvent"
+          <dl data-link-for="BidirectionalStreamWithDataEvent" data-dfn-for="BidirectionalStreamWithDataEvent"
           class="constructors">
-            <dt><code>NewBidirectionalStreamWithDataEvent</code></dt>
+            <dt><code>BidirectionalStreamWithDataEvent</code></dt>
             <dd>
               <table class="parameters">
                 <tbody>
@@ -660,7 +660,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                   </tr>
                   <tr>
                     <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>NewBidirectionalStreamWithDataEventInit</a></code></td>
+                    <td class="prmType"><code><a>BidirectionalStreamWithDataEventInit</a></code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -674,7 +674,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="NewBidirectionalStreamWithDataEvent" data-dfn-for="NewBidirectionalStreamWithDataEvent"
+          <dl data-link-for="BidirectionalStreamWithDataEvent" data-dfn-for="BidirectionalStreamWithDataEvent"
           class="attributes">
             <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicBidirectionalStream</a></span>, readonly</dt>
@@ -687,15 +687,15 @@ interface NewBidirectionalStreamWithDataEvent : Event {
         </section>
       </div>
       <div>
-          <p>The <dfn><code>NewBidirectionalStreamWithDataEventInit</code></dfn> dictionary includes
+          <p>The <dfn><code>BidirectionalStreamWithDataEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary NewBidirectionalStreamWithDataEventInit : EventInit {
+        <pre class="idl">dictionary BidirectionalStreamWithDataEventInit : EventInit {
              RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
-          <h2>Dictionary NewBidirectionalStreamWithDataEventInit Members</h2>
-          <dl data-link-for="NewBidirectionalStreamWithDataEventInit" data-dfn-for=
-          "NewBidirectionalStreamWithDataEventInit" class="dictionary-members">
+          <h2>Dictionary BidirectionalStreamWithDataEventInit Members</h2>
+          <dl data-link-for="BidirectionalStreamWithDataEventInit" data-dfn-for=
+          "BidirectionalStreamWithDataEventInit" class="dictionary-members">
             <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicBidirectionalStream</a></span></dt>
             <dd>
@@ -863,7 +863,35 @@ interface NewBidirectionalStreamWithDataEvent : Event {
               <td>
                 <p>The QUIC connection has been closed as the result of an error (such as
                 receipt of an error alert or a failure to validate the remote
-                fingerprint).</p>
+                fingerprint). When the <code><a>RTCQuicTransport</a></code>'s
+                internal <a>[[\QuicTransportState]]</a> slot transitions to
+                <code>failed</code> the user agent <em class="rfc2119" title="MUST">MUST</em>
+                run the following steps:</p>
+                <ol>
+                  <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>.
+                  <li>For each RTCQuicReadableStream in <var>transport</var>'s
+                  <a>[[\QuicTransportReadableStreams]]</a> internal slot run the
+                  following:</li>
+                  <ol>
+                    <li>Let <var>stream</var> be the RTCQuicReadableStream.</li>
+                    <li>Set <var>stream</var>'s <a>[[\Readable]]</a> slot to
+                    <code>false</code>.</li>
+                    <li>Clear the <var>stream</var>'s read buffer.</li>
+                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                    <a>[[\QuicTransportReadableStreams]]</a> internal slot.
+                  </ol>
+                  <li>For each RTCQuicWritableStream in <var>transport</var>'s
+                  <a>[[\QuicTransportWritableStreams]]</a> internal slot run the
+                  following:</li>
+                  <ol>
+                    <li>Let <var>stream</var> be the RTCQuicWritableStream.</li>
+                    <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to
+                    <code>false</code>.</li>
+                    <li>Clear the <var>stream</var>'s write buffer.</li>
+                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                    <a>[[\QuicTransportWritableStreams]]</a> internal slot.
+                  </ol>
+                </ol>
               </td>
             </tr>
           </tbody>
@@ -887,7 +915,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       following ways:</p>
       <ol>
         <li>Using the <code><a>RTCQuicTransport</a>.createBidirectionalStream</code></li>
-        <li>Getting a <code><a>newbidirectionalstreamwithdata</a></code> event on the
+        <li>Getting a <code><a>bidirectionalstreamwithdata</a></code> event on the
         <code><a>RTCQuicTransport</a></code></li>
       </ol>
       <p>A <code><a>RTCQuicSendStream</a></code> can be created in the following
@@ -898,7 +926,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
       <p>A <code><a>RTCQuicReceiveStream</a></code> can be created in the following
       ways:</p>
       <ol>
-        <li>Getting a <code><a>newreceivestreamwithdata</a></code> event on the
+        <li>Getting a <code><a>receivestreamwithdata</a></code> event on the
         <code><a>RTCQuicTransport</a></code></li>
       </ol>
     </section>
@@ -1156,6 +1184,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
             readonly attribute Promise&lt;RTCQuicStreamAbortInfo&gt; readingAborted;
             RTCQuicStreamReadResult readInto (Uint8Array data);
             void abortReading (RTCQuicStreamAbortInfo abortInfo);
+            Promise&lt;void&gt;   waitForReadable(unsigned long amount);
         };
         </pre>
         <section>
@@ -1620,21 +1649,21 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           <td>The <code><a>RTCQuicTransportState</a></code> changed.</td>
         </tr>
         <tr>
-          <td><dfn><code>newreceivestreamwithdata</code></dfn></td>
-          <td><code><a>NewReceiveStreamWithDataEvent</a></code></td>
+          <td><dfn><code>receivestreamwithdata</code></dfn></td>
+          <td><code><a>ReceiveStreamWithDataEvent</a></code></td>
           <td>A new <code><a>RTCQuicReceiveStream</a></code> is dispatched to the
           script in response to the remote peer creating a send only QUIC stream and
-          sending data on it. Prior to <code><a>newreceivestreamwithdata</a></code>
+          sending data on it. Prior to <code><a>receivestreamwithdata</a></code>
           firing, the <code><a>RTCQuicReceiveStream</a></code> is added to
           <code><a>RTCQuicTransport</a></code>'s<a>[[\QuicTransportReadableStreams]]</a>
           internal slot.</td>
         </tr>
         <tr>
-          <td><dfn><code>newbidirectionalstreamwithdata</code></dfn></td>
-          <td><code><a>NewBidirectionalStreamWithDataEvent</a></code></td>
+          <td><dfn><code>bidirectionalstreamwithdata</code></dfn></td>
+          <td><code><a>BidirectionalStreamWithDataEvent</a></code></td>
           <td>A new <code><a>RTCQuicBidirectionalStream</a></code> is dispatched to the
           script in response to the remote peer creating a bidirectional QUIC stream and
-          sending data on it. Prior to <code><a>newbidirectionalstreamwithdata</a></code>
+          sending data on it. Prior to <code><a>bidirectionalstreamwithdata</a></code>
           firing, the <code><a>RTCQuicBidirectionalStream</a></code> is added to both the
           <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportReadableStreams]]</a>
           and <a>[[\QuicTransportWritableStreams]]</a> internal slot.</td>

--- a/index.html
+++ b/index.html
@@ -88,8 +88,10 @@
     to QUIC transport.</p>
     <section id="rtcquictransport-overview*">
       <h3>Overview</h3>
-      <p>An <code><a>RTCQuicTransport</a></code> instance is associated to
-      one or more <code><a>RTCQuicStream</a></code> instances.</p>
+      <p>An <code><a>RTCQuicTransport</a></code> instance can be associated to
+      one or more <code><a>RTCQuicBidirectionalStream</a></code>,
+      <code><a>RTCQuicSendStream</a></code>, or <code><a>RTCQuicReceiveStream</a></code>
+      instances.</p>
       <p class="note">The QUIC API presented in this and the subsequent
       section represents a preliminary proposal based on work-in-progress
       within the IETF QUIC WG. Since the QUIC transport specification is
@@ -136,10 +138,12 @@ interface RTCQuicTransport : RTCStatsProvider {
     sequence&lt;ArrayBuffer&gt; getRemoteCertificates ();
     void                  start (RTCQuicParameters remoteParameters);
     void                  stop ();
-    RTCQuicStream         createStream (optional RTCQuicStreamParameters parameters);
+    RTCQuicBidirectionalStream         createBidirectionalStream ();
+    RTCQuicSendStream                  createSendStream ();
                     attribute EventHandler             onstatechange;
                     attribute EventHandler             onerror;
-                    attribute EventHandler             onquicstream;
+                    attribute EventHandler             onnewreceivestreamwithdata;
+                    attribute EventHandler             onnewbidirectionalstreamwithdata;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -170,8 +174,8 @@ interface RTCQuicTransport : RTCStatsProvider {
               <code><a>RTCQuicTransport</a></code> object.
             </li>
             <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportStreams]]</dfn>
-            internal slot representing a sequence of <code><a>RTCQuicStream</a></code>
-            objects, initialized to empty.
+            internal slot representing a sequence of (<code><a>RTCQuicWritableStream</a></code>
+            or <code><a>RTCQuicReadableStream</a></code>) objects, initialized to empty.
             </li>
             <li>
               Let <var>quictransport</var> have a <dfn>[[\QuicTransportState]]</dfn>
@@ -264,12 +268,22 @@ interface RTCQuicTransport : RTCStatsProvider {
               "SHOULD">SHOULD</em> include QUIC error information in
               <var>error.message</var> (defined in [[!HTML51]] Section 7.1.3.8.2).</p>
             </dd>
-            <dt><dfn><code>onquicstream</code></dfn> of type <span class=
+            <dt><dfn><code>onnewreceivestreamwithdata</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
-              <p>This event handler, of event handler event type <code><a>quicstream</a></code>,
-              <em class="rfc2119" title="MUST">MUST</em> be fired on when a remote
-              <code><a>RTCQuicStream</a></code> is created.
+              <p>This event handler, of event handler event type
+              <code><a>newreceivestreamwithdata</a></code>,
+              <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
+              from a newly created remote <code><a>RTCQuicSendStream</a></code>.
+              </p>
+            </dd>
+            <dt><dfn><code>onnewbidirectionalstreamwithdata</code></dfn> of type <span class=
+            "idlAttrType"><a>EventHandler</a></span></dt>
+            <dd>
+              <p>This event handler, of event handler event type
+              <code><a>newbidirectionalstreamwithdata</a></code>,
+              <em class="rfc2119" title="MUST">MUST</em> be fired on when when data is received
+              from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code>.
               </p>
             </dd>
           </dl>
@@ -390,10 +404,7 @@ interface RTCQuicTransport : RTCStatsProvider {
                 then abort these steps.</li>
                 <li>Set <var>transport</var>'s <a>[[\QuicTransportState]]</a> to
                 <code>"closed"</code>.</li>
-                <li>Set <var>stream</var>'s <a>[[\State]]</a> slot to <code>"closed"</code>
-                for each <code><a>RTCQuicStream</a></code> <var>stream</var> in <var>transport</var>'s
-                <a>[[\QuicTransportStreams]]</a> slot.</li>
-                <li>Start the "Immediate Close" procedure by sending a closing frame.</li>
+                <li>Start the "Immediate Close" procedure by sending an APPLICATION_CLOSE frame.</li>
               </ol>
               <div>
                 <em>No parameters.</em>
@@ -402,62 +413,27 @@ interface RTCQuicTransport : RTCStatsProvider {
                 <em>Return type:</em> <code>void</code>
               </div>
             </dd>
-           <dt><dfn><code>createStream</code></dfn></dt>
+           <dt><dfn><code>createBidirectionalStream</code></dfn></dt>
             <dd>
-              <p>Creates an <code><a>RTCQuicStream</a></code> object.
+              <p>Creates an <code><a>RTCQuicBidirectionalStream</a></code> object.
               Since [[QUIC-TRANSPORT]] only defines reliable QUIC streams,
-              <code>createStream</code> only supports creation of reliable
+              <code>createBidectionalStream</code> only supports creation of reliable
               streams.</p>
-              <p>When <code>createStream</code> is called, the user agent
+              <p>When <code>createBidectionalStream</code> is called, the user agent
               <em class="rfc2119" title="MUST">MUST</em> run the following
               steps:</p>
               <ol>
                 <li>
                   <p>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>
-                  on which <code>createStream</code> is invoked.</p>
+                  on which <code>createBidectionalStream</code> is invoked.</p>
                 </li>
                 <li>
-                  <p>If <code><var>transport</var>.state</code> is <code>closed</code>
+                  <p>If <code><var>transport</var>'s state</code> is not <code>connected</code>
                   <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</p>
                 </li>
                 <li>
-                  <p>Let <var>parameters</var> be the first argument if provided,
-                  <code>null</code> otherwise.</p>
-                </li>
-                <li>
-                  <p>if <var>parameters</var> is non-null, let <var>direction</var>
-                  be <var>parameters</var>'s <code>direction</code>
-                  member, <code>"sendrecv"</code> otherwise.</p>
-                </li>
-                <li>
-                  <p>If <var>direction</var> is <code>"recv"</code> <a>throw</a> an
-                  <code>OperationError</code> and abort these steps.</p>
-                <li>
                   <p>Let <var>stream</var> be a newly created
-                  <code><a>RTCQuicStream</a></code> object.</p>
-                </li>
-                <li>
-                  <p>Let <var>stream</var> have a <dfn>[[\State]]</dfn>
-                  internal slot initialized to <code>"new"</code>.</p>
-                </li>
-                <li><p>Let <var>stream</var> have a <dfn>[[\Direction]]</dfn>
-                  internal slot initialized to <var>direction</var>.</p>
-                </li>
-                <li>
-                  <p>Let <var>stream</var> have a <dfn>[[\Readable]]</dfn> internal
-                  slot initialized to <code>false</code>.</p>
-                </li>
-                <li>
-                  <p>Let <var>stream</var> have a <dfn>[[\Writable]]</dfn> internal
-                  slot initialized to <code>false</code>.</p>
-                </li>
-                <li>
-                  <p>Let <var>stream</var> have a <dfn>[[\WriteBufferedAmount]]</dfn> internal
-                  slot initialized to zero.</p>
-                </li>
-                <li>
-                  <p>Let <var>stream</var> have a <dfn>[[\ReadableAmount]]</dfn> internal
-                  slot initialized to zero.</p>
+                  <code><a>RTCQuicBidirectionalStream</a></code> object.</p>
                 </li>
                 <li>
                   <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
@@ -472,52 +448,56 @@ interface RTCQuicTransport : RTCStatsProvider {
                   transport.</p>
                 </li>
               </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">parameters</td>
-                    <td class="prmType"><code><a>RTCQuicStreamParameters</a></code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptTrue"><span role="img" aria-label=
-                    "True">&#10004;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
               <div>
-                <em>Return type:</em> <code><a>RTCQuicStream</a></code>
+                <em>No parameters.</em>
+              </div>
+              <div>
+                <em>Return type:</em> <code><a>RTCQuicBidirectionalStream</a></code>
               </div>
             </dd>
-          </dl>
-        </section>
-      </div>
-    </section>
-    <section id="rtcquicstreamparameters*">
-      <h3><dfn>RTCQuicStreamParameters</dfn> Dictionary</h3>
-      <p>The <code>RTCQuicStreamParameters</code> dictionary includes information
-      relating to QUIC stream configuration.</p>
-      <div>
-        <pre class="idl">dictionary RTCQuicStreamParameters {
-             RTCQuicStreamDirection                  direction = "sendrecv";
-};</pre>
-        <section>
-          <h2>Dictionary <a class="idlType">RTCQuicStreamParameters</a> Members</h2>
-          <dl data-link-for="RTCQuicStreamParameters" data-dfn-for="RTCQuicStreamParameters" class=
-          "dictionary-members">
-            <dt><dfn><code>direction</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCQuicStreamDirection</a></span>, defaulting to
-            <code>"sendrecv"</code></dt>
+           <dt><dfn><code>createSendStream</code></dfn></dt>
             <dd>
-              <p>The QUIC stream direction, with a default of <code>"sendrecv"</code>.</p>
+              <p>Creates an <code><a>RTCQuicSendStream</a></code> object.
+              Since [[QUIC-TRANSPORT]] only defines reliable QUIC streams,
+              <code>createSendStream</code> only supports creation of reliable
+              streams.</p>
+              <p>When <code>createSendStream</code> is called, the user agent
+              <em class="rfc2119" title="MUST">MUST</em> run the following
+              steps:</p>
+              <ol>
+                <li>
+                  <p>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>
+                  on which <code>createSendStream</code> is invoked.</p>
+                </li>
+                <li>
+                  <p>If <code><var>transport</var>'s state</code> is not <code>connected</code>
+                  <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</p>
+                </li>
+                <li>
+                  <p>Let <var>stream</var> be a newly created
+                  <code><a>RTCQuicSendStream</a></code> object.</p>
+                </li>
+                <li>
+                  <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
+                  internal slot. </p>
+                </li>
+                <li>
+                  <p>Return <var>stream</var> and continue the following steps
+                  in the background.</p>
+                </li>
+                <li>
+                  <p>Create <var>stream</var>'s associated underlying data
+                  transport.</p>
+                </li>
+              </ol>
+              <div>
+                <em>No parameters.</em>
+              </div>
+              <div>
+                <em>Return type:</em> <code><a>RTCQuicSendStream</a></code>
+              </div>
             </dd>
+
           </dl>
         </section>
       </div>
@@ -553,20 +533,20 @@ interface RTCQuicTransport : RTCStatsProvider {
       </div>
     </section>
     <section>
-      <h3><dfn>RTCQuicStreamEvent</dfn></h3>
-      <p>The <code><a>quicstream</a></code> event uses the
-      <code><a>RTCQuicStreamEvent</a></code> interface.</p>
+      <h3><dfn>NewReceiveStreamWithDataEvent</dfn></h3>
+      <p>The <code><a>newreceivestreamwithdata</a></code> event uses the
+      <code><a>NewReceiveStreamWithDataEvent</a></code> interface.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, RTCQuicStreamEventInit eventInitDict), Exposed=Window]
-interface RTCQuicStreamEvent : Event {
-    readonly        attribute RTCQuicStream stream;
+        [ Constructor (DOMString type, NewReceiveStreamWithDataEventInit eventInitDict), Exposed=Window]
+interface NewReceiveStreamWithDataEvent : Event {
+    readonly        attribute RTCQuicReceiveStream receiveStream;
 };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="RTCQuicStreamEvent" data-dfn-for="RTCQuicStreamEvent"
+          <dl data-link-for="NewReceiveStreamWithDataEvent" data-dfn-for="NewReceiveStreamWithDataEvent"
           class="constructors">
-            <dt><code>RTCQuicStreamEvent</code></dt>
+            <dt><code>NewReceiveStreamWithDataEvent</code></dt>
             <dd>
               <table class="parameters">
                 <tbody>
@@ -588,7 +568,7 @@ interface RTCQuicStreamEvent : Event {
                   </tr>
                   <tr>
                     <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>RTCQuicStreamEventInit</a></code></td>
+                    <td class="prmType"><code><a>NewReceiveStreamWithDataEventInit</a></code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -602,80 +582,120 @@ interface RTCQuicStreamEvent : Event {
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicStreamEvent" data-dfn-for="RTCQuicStreamEvent"
+          <dl data-link-for="NewReceiveStreamWithDataEvent" data-dfn-for="NewReceiveStreamWithDataEvent"
           class="attributes">
-            <dt><code>stream</code> of type <span class=
-            "idlAttrType"><a>RTCQuicStream</a></span>, readonly</dt>
+            <dt><code>receiveStream</code> of type <span class=
+            "idlAttrType"><a>RTCQuicReceiveStream</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-quicstreamevent-stream"><code>stream</code></dfn>
-              attribute represents the <code><a>RTCQuicStream</a></code> object
-              associated with the event. The <code><a>RTCQuicStream</a></code> object's
-              <a>[[\Direction]]</a> internal slot is set to the value <code>"recv"</code>
-              if the remote peer created a <code>"send"</code> stream, otherwise it
-              is set to <code>"sendrecv"</code>.</p>
+              <p>The <dfn id="dom-receivequicstreamevent-stream"><code>receiveStream</code></dfn>
+              attribute represents the <code><a>RTCQuicReceiveStream</a></code> object
+              associated with the event.</p>
             </dd>
           </dl>
         </section>
       </div>
       <div>
-          <p>The <dfn><code>RTCQuicStreamEventInit</code></dfn> dictionary includes
+          <p>The <dfn><code>NewReceiveStreamWithDataEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary RTCQuicStreamEventInit : EventInit {
-             RTCQuicStream stream;
+        <pre class="idl">dictionary NewReceiveStreamWithDataEventInit : EventInit {
+             RTCQuicReceiveStream receiveStream;
 };</pre>
         <section>
-          <h2>Dictionary RTCQuicStreamEventInit Members</h2>
-          <dl data-link-for="RTCQuicStreamEventInit" data-dfn-for=
-          "RTCQuicStreamEventInit" class="dictionary-members">
-            <dt><dfn><code>stream</code></dfn> of type <span class=
-            "idlMemberType"><a>RTCQuicStream</a></span></dt>
+          <h2>Dictionary NewReceiveStreamWithDataEventInit Members</h2>
+          <dl data-link-for="NewReceiveStreamWithDataEventInit" data-dfn-for=
+          "NewReceiveStreamWithDataEventInit" class="dictionary-members">
+            <dt><dfn><code>receiveStream</code></dfn> of type <span class=
+            "idlMemberType"><a>RTCQuicReceiveStream</a></span></dt>
             <dd>
-              <p>The <code><a>RTCQuicStream</a></code> object associated with the
-              event. The <code><a>RTCQuicStream</a></code> object's
-              <a>[[\Direction]]</a> internal slot is set to the value <code>"recv"</code>
-              if the remote peer created a <code>"send"</code> stream, otherwise it
-              is set to <code>"sendrecv"</code>.</p>
+              <p>The <code><a>RTCQuicReceiveStream</a></code> object associated with the
+              event.</p>
             </dd>
           </dl>
         </section>
       </div>
     </section>
-    <section id="rtcquicstreamdirection*">
-      <h3><dfn>RTCQuicStreamDirection</dfn> Enum</h3>
-      <p><code>RTCQuicStreamDirection</code> indicates the direction of the QUIC stream.</p>
+    <section>
+      <h3><dfn>NewBidirectionalStreamWithDataEvent</dfn></h3>
+      <p>The <code><a>newbidirectionalstreamwithdata</a></code> event uses the
+      <code><a>NewBidirectionalStreamWithDataEvent</a></code> interface.</p>
       <div>
-        <pre class="idl">enum RTCQuicStreamDirection {
-    "sendrecv",
-    "recv",
-    "send"
+        <pre class="idl">
+        [ Constructor (DOMString type, NewBidirectionalStreamWithDataEventInit eventInitDict), Exposed=Window]
+interface NewBidirectionalStreamWithDataEvent : Event {
+    readonly        attribute RTCQuicBidirectionalStream bidirectionalStream;
 };</pre>
-        <table data-link-for="RTCQuicStreamDirection" data-dfn-for="RTCQuicStreamDirection" class="simple">
-          <tbody>
-            <tr>
-              <th colspan="2">Enumeration description</th>
-            </tr>
-            <tr>
-              <td><dfn><code id="idl-def-RTCQuicStreamDirection.sendrecv">sendrecv</code></dfn></td>
-              <td>
-                <p>A bi-directional QUIC stream.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id="idl-def-RTCQuicStreamDirection.recv">recv</code></dfn></td>
-              <td>
-                <p>A uni-directional stream created by the remote endpoint.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id="idl-def-RTCQuicStreamDirection.send">send</code></dfn></td>
-              <td>
-                  <p>A uni-directional stream created by the local endpoint.</p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <section>
+          <h2>Constructors</h2>
+          <dl data-link-for="NewBidirectionalStreamWithDataEvent" data-dfn-for="NewBidirectionalStreamWithDataEvent"
+          class="constructors">
+            <dt><code>NewBidirectionalStreamWithDataEvent</code></dt>
+            <dd>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">type</td>
+                    <td class="prmType"><code>DOMString</code></td>
+                    <td class="prmNullFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmOptFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">eventInitDict</td>
+                    <td class="prmType"><code><a>NewBidirectionalStreamWithDataEventInit</a></code></td>
+                    <td class="prmNullFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmOptFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="NewBidirectionalStreamWithDataEvent" data-dfn-for="NewBidirectionalStreamWithDataEvent"
+          class="attributes">
+            <dt><code>bidirectionalStream</code> of type <span class=
+            "idlAttrType"><a>RTCQuicBidirectionalStream</a></span>, readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-bidirectionalquicstreamevent-stream"><code>bidirectionalStream</code></dfn>
+              attribute represents the <code><a>RTCQuicBidirectionalStream</a></code> object
+              associated with the event.</p>
+            </dd>
+          </dl>
+        </section>
       </div>
-    </section>              
+      <div>
+          <p>The <dfn><code>NewBidirectionalStreamWithDataEventInit</code></dfn> dictionary includes
+          information on the configuration of the QUIC stream.</p>
+        <pre class="idl">dictionary NewBidirectionalStreamWithDataEventInit : EventInit {
+             RTCQuicBidirectionalStream bidirectionalStream;
+};</pre>
+        <section>
+          <h2>Dictionary NewBidirectionalStreamWithDataEventInit Members</h2>
+          <dl data-link-for="NewBidirectionalStreamWithDataEventInit" data-dfn-for=
+          "NewBidirectionalStreamWithDataEventInit" class="dictionary-members">
+            <dt><dfn><code>bidirectionalStream</code></dfn> of type <span class=
+            "idlMemberType"><a>RTCQuicBidirectionalStream</a></span></dt>
+            <dd>
+              <p>The <code><a>RTCQuicBidirectionalStream</a></code> object associated with the
+              event.</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
     <section id="rtcquicrole*">
       <h3><dfn>RTCQuicRole</dfn> Enum</h3>
       <p><code>RTCQuicRole</code> indicates the role of the QUIC
@@ -796,12 +816,33 @@ interface RTCQuicStreamEvent : Event {
               <td>
                 <p>The QUIC connection has been closed intentionally via a call to
                 <code>stop()</code> or receipt of a closing frame as described in
-                [[QUIC-TRANSPORT]] section 6.13.3. When receiving a closing frame
-                the user agent <em class="rfc2119" title="MUST">MUST</em> set
-                the <var>stream</var>'s <a>[[\State]]</a> slot to
-                <code>"closed"</code> for each <code><a>RTCQuicStream</a></code>
-                <var>stream</var> in <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
-                internal slot.</p>
+                [[QUIC-TRANSPORT]]. When the <code><a>RTCQuicTransport</a></code>'s
+                internal <a>[[\QuicTransportState]]</a> slot transitions to
+                <code>closed</code> the user agent <em class="rfc2119" title="MUST">MUST</em>
+                run the following steps:</p>
+                <ol>
+                  <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>.
+                  <li>For each RTCQuicReadableStream in <var>transport</var>'s
+                  <a>[[\QuicTransportStreams]]</a> internal slot run the following:</li>
+                  <ol>
+                    <li>Let <var>stream</var> be the RTCQuicReadableStream.</li>
+                    <li>Set <var>stream</var>'s <a>[[\Readable]]</a> slot to
+                    <code>false</code>.</li>
+                    <li>Clear the <var>stream</var>'s read buffer.</li>
+                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                    <a>[[\QuicTransportStreams]]</a> internal slot.
+                  </ol>
+                  <li>For each RTCQuicWritableStream in <var>transport</var>'s
+                  <a>[[\QuicTransportStreams]]</a> internal slot run the following:</li>
+                  <ol>
+                    <li>Let <var>stream</var> be the RTCQuicWritableStream.</li>
+                    <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to
+                    <code>false</code>.</li>
+                    <li>Clear the <var>stream</var>'s write buffer.</li>
+                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                    <a>[[\QuicTransportStreams]]</a> internal slot.
+                  </ol>
+                </ol>
               </td>
             </tr>
             <tr>
@@ -819,84 +860,79 @@ interface RTCQuicStreamEvent : Event {
     </section>
   </section>
   <section id="quicstream*">
-    <h2><dfn>RTCQuicStream</dfn> Interface</h2>
-    <p>The <code>RTCQuicStream</code> includes information relating
+    <h2><dfn>QUIC Stream API</dfn></h2>
+    <p>The <code>QUIC Stream API</code> includes information relating
     to a QUIC stream. </p>
     <section id="rtcquicstream-overview*">
       <h3>Overview</h3>
-      <p>An <code><a>RTCQuicStream</a></code> instance is associated to
-      an <code><a>RTCQuicTransport</a></code> instance.</p>
+      <p><code><a>RTCQuicBidirectionalStream</a></code>, <code><a>RTCQuicSendStream</a></code>,
+      and <code><a>RTCQuicReceiveStream</a></code> instances are associated to
+      a <code><a>RTCQuicTransport</a></code> instance.</p>
     </section>
     <section id="rtcquicstream-operation*">
       <h3>Operation</h3>
-      <p>An <code><a>RTCQuicStream</a></code> instance is constructed
-      using the <code><a>RTCQuicTransport</a>.createStream</code> method.</p>
+      <p>A <code><a>RTCQuicBidirectionalStream</a></code> can be created in the
+      following ways:</p>
+      <ol>
+        <li>Using the <code><a>RTCQuicTransport</a>.createBidirectionalStream</code></li>
+        <li>Getting a <code><a>newbidirectionalstreamwithdata</a></code> event on the
+        <code><a>RTCQuicTransport</a></code></li>
+      </ol>
+      <p>A <code><a>RTCQuicSendStream</a></code> can be created in the following
+      ways:</p>
+      <ol>
+        <li>Using the <code><a>RTCQuicTransport</a>.createSendStream</code></li>
+      </ol>
+      <p>A <code><a>RTCQuicReceiveStream</a></code> can be created in the following
+      ways:</p>
+      <ol>
+        <li>Getting a <code><a>newreceivestreamwithdata</a></code> event on the
+        <code><a>RTCQuicTransport</a></code></li>
+      </ol>
     </section>
-    <section id="rtcquicstream-interface-definition*">
-      <h3>Interface Definition</h3>
+    <section id="rtcquicwritablestream-interface-mixin-definition*">
+      <h3>Interface Mixin <dfn>RTCQuicWritableStream</dfn></h3>
       <div>
         <pre class="idl">
         [ Exposed=Window ]
-interface RTCQuicStream {
-    readonly        attribute RTCQuicTransport    transport;
-    readonly        attribute RTCQuicStreamState  state;
-    readonly        attribute unsigned long       readableAmount;
-    readonly        attribute unsigned long       writeBufferedAmount;
-    RTCQuicStreamParameters getParameters();
-    long                  readInto (Uint8Array data);
-    void                  write (Uint8Array data);
-    void                  finish ();
-    void                  reset ();
-    Promise&lt;void&gt;   waitForReadable(unsigned long amount);
-    Promise&lt;void&gt;   waitForWriteBufferedAmountBelow(unsigned long threshold);
-                    attribute EventHandler        onstatechange;
-};</pre>
+        interface mixin RTCQuicWritableStream {
+            readonly attribute boolean writable;
+            readonly attribute unsigned long writeBufferedAmount;
+            readonly attribute Promise&lt;RTCQuicStreamAbortInfo&gt; writingAborted;
+            void write (RTCQuicStreamWriteParameters data);
+            void abortWriting (RTCQuicStreamAbortInfo errorInfo);
+            Promise&lt;void&gt; waitForWriteBufferedAmountBelow(unsigned long threshold);
+        };
+        </pre>
+        <section>
+          <h2>Overview</h2>
+          <p>The <code><a>RTCQuicWritableStream</a></code> will initialize with
+          the following:</p>
+          <ol>
+            <li>Let <var>stream</var> be the <code><a>RTCQuicWritableStream</a></code>.</li>
+            <li>Let <var>stream</var> have a <dfn>[[\Writable]]</dfn> internal
+            slot initialized to <code>true</code>.</li>
+            <li>Let <var>stream</var> have a <dfn>[[\WriteBufferedAmount]]</dfn> internal
+            slot initialized to zero.</li>
+          </ol>
+        </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="RTCQuicStream" data-dfn-for="RTCQuicStream" class=
+          <dl data-link-for="RTCQuicWritableStream" data-dfn-for="RTCQuicWritableStream" class=
           "attributes">
-            <dt><dfn><code>transport</code></dfn> of type <span class=
-            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
+            <dt><code>writable</code> of type <span class=idlAttriType"><a>boolean</a>
+            readonly</dt>
             <dd>
-              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
-            </dd>
-            <dt><code>state</code> of type <span class=
-            "idlAttrType"><a>RTCQuicStreamState</a></span>, readonly</dt>
-            <dd>
-              <p>The <dfn id="dom-quicstream-state"><code>state</code></dfn>
-              attribute represents the state of the <a>RTCQuicStream</a> object.
-              On getting it <em class="rfc2119" title="MUST">MUST</em> return
-              the value of the <code><a>RTCQuicStream</a></code>'s
-              <a>[[\State]]</a> internal slot.</p>
-            </dd>
-            <dt><dfn><code>onstatechange</code></dfn> of type <span class=
-            "idlAttrType"><a>EventHandler</a></span></dt>
-            <dd>
-             <p>This event handler, of event handler event type
-              <code><a>statechange</a></code>, <em class="rfc2119" title="MUST">MUST</em>
-              be fired any time the <code><a>RTCQuicStreamState</a></code>
-              changes.</p>
-            </dd>
-            <dt><code>readableAmount</code> of type <span class="idlAttrType"><a>unsigned
-            long</a></span>, readonly</dt>
-            <dd>
-              <p>The <dfn id="dom-quicstream-readableamount"><code>readableAmount</code></dfn>
-              attribute represents the number of bytes buffered for access by
-              <code>readInto</code> but that, as of the last time the event loop
-              started executing a task, had not yet been read. This does not include
-              framing overhead incurred by the protocol, or buffers associated with
-              the network hardware. On getting, it <em class="rfc2119" title="MUST">MUST</em>
-              return the value of the <code><a>RTCQuicStream</a></code>'s
-              <a>[[\ReadableAmount]]</a> internal slot.
-              If the <code><a>RTCQuicStream</a></code> is in the <code>closed</code> state,
-              this attribute's value will only decrease with each call to the
-              <code>readInto</code> method (the attribute does not reset to zero once the
-              <code><a>RTCQuicStream</a></code> closes).</p>
+              <p>The <dfn id="dom-rtcquicwritablestream-writable"><code>writable</code></dfn>
+              attribute represents whether data can be written to the
+              <code><a>RTCQuicWritableStream</a></code>. On getting it
+              <em class="rfc2119" title="MUST">MUST</em> return the value of the
+              <a>[[\Writable]]</a> slot.</p>
             </dd>
             <dt><code>writeBufferedAmount</code> of type <span class="idlAttrType"><a>unsigned
             long</a></span>, readonly</dt>
             <dd>
-              <p>The <dfn id="dom-quicstream-writebufferedamount"><code>writeBufferedAmount</code></dfn>
+              <p>The <dfn id="dom-rtcquicwritablestream-writable"><code>writeBufferedAmount</code></dfn>
               attribute represents the number of bytes of application data
               that have been queued using <code>write</code> but that, as of the last
               time the event loop started executing a task, had not yet been transmitted
@@ -906,63 +942,301 @@ interface RTCQuicStream {
               include framing overhead incurred by the protocol, or buffering done
               by the operating system or network hardware. On getting, it
               <em class="rfc2119" title="MUST">MUST</em> return the value of the
-              <code><a>RTCQuicStream</a></code>'s <a>[[\WriteBufferedAmount]]</a> internal slot.
-              If the <code><a>RTCQuicStream</a></code> is in the <code>closed</code>
-              state, this attribute's value will only increase with each call to the
-              <code>write</code> method (the attribute does not reset to zero once the
-              <code><a>RTCQuicStream</a></code> closes).</p>
+              RTCQuicWritableStream's <a>[[\WriteBufferedAmount]]</a> internal slot.
+            </dd>
+            <dt><code>writingAborted</code> of type <span class=idlAttriType"><a>RTCQuicStreamAbortInfo</a>
+            readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-rtcquicwritablestream-writingAborted"><code>writingAborted</code></dfn>
+              attribute represents a promise that <a>resolves</a> when the
+              STOP_SENDING frame is received from the <code><a>RTCQuicReadableStream</a></code>.
+              When the <var>stream</var> receives a STOP_SENDING frame from its corresponding
+              <code><a>RTCQuicReadableStream</a></code>, the <a>user agent</a>
+              <em class="rfc2119" title="MUST">MUST</em> run the following:
+              <ol>
+                <li>Let <var>stream</var> be the <code><a>RTCQuicWritableStream</a></code> object.
+                <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to <code>false</code>.</li>
+                <li>Clear the <var>stream</var>'s write buffer.</li>
+                <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                which the <var>stream</var> was created from.
+                <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <li><a>resolve</a> the promise with the resulting
+                <code><a>RTCQuicStreamAbortInfo</a></code> with the <code>errorCode</code>
+                set to the value from the STOP_SENDING frame.</li>
+              </ol>
             </dd>
           </dl>
        </section>
        <section>
           <h2>Methods</h2>
-          <dl data-link-for="RTCQuicStream" data-dfn-for="RTCQuicStream" class=
+          <dl data-link-for="RTCQuicWritableStream" data-dfn-for="RTCQuicWritableStream" class=
           "methods">
-            <dt><dfn><code>getParameters</code></dfn></dt>
+            <dt><dfn><code>write</code></dfn></dt>
             <dd>
-              <p>Returns the <code><a>RTCQuicStreamParameters</a></code> applying to this
-              QUIC stream. When the <code>getParameters</code> method is called, the user
-              agent <em class="rfc2119" title="MUST">MUST</em> run the following
-              steps:</p>
+              <p>Writes data to the stream. When the remote <code><a>RTCQuicTransport</a></code>
+              receives the STREAM frame from this stream for the first time, it will trigger the
+              creation of the corresponding remote stream. When the <code>write</code> method is
+              called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em>
+              run the following steps:</p>
               <ol>
-                 <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code> object
-                 for which parameters are to be returned.</li>
-                 <li>Let <var>parameters</var> be a new
-                 <code><a>RTCQuicStreamParameters</a></code> dictionary.</li>
-                 <li>Set <var>parameters</var>'s <dfn id="dom-quicstream-direction"><code>direction</code></dfn>
-                 member to the value of <var>stream</var>'s <a>[[\Direction]]</a> internal slot,
-                 which <em class="rfc2119" title="MUST">MUST</em> have the value to which it was set when
-                 <var>stream</var> was created.</li>
-                 <li>Return <var>parameters</var>.</li>
+               <li>Let <var>data</var> be the first argument.</li>
+               <li>Let <var>stream</var> be the RTCQuicWritableStream
+               object on which <var>data</var> is to be sent.</li>
+               <li>if length of <var>data</var>.data is 0 and <var>data</var>.finished is
+               <code>false</code>, <a>throw</a> a <code>NotSupportedError</code> and abort
+               these steps.</li>
+               <li>If <var>stream</var>'s <a>[[\Writable]]</a> slot is <code>false</code>,
+               <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</li>
+               <li>Increase the value of <var>stream</var>'s
+               <a>[[\WriteBufferedAmount]]</a> slot by the length of
+               <var>data</var>.data in bytes.</li>
+               <li>Queue <var>data</var>.data for transmission on <var>stream</var>'s
+               underlying data transport.</li>
+               <li>Queue a STREAM frame with the FIN bit set if <var>data</var>.finish
+               is set to <code>true</code>.
+               <div class="note">The actual transmission of data occurs in
+               parallel. If sending data leads to a QUIC-level error, the
+               application will be notified asynchronously through the
+               <code><a>RTCQuicTransport</a></code>'s <code><a>onerror</a></code>
+               EventHandler.</div></li>
               </ol>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">data</td>
+                    <td class="prmType"><code>RTCQuicStreamWriteParameters</code></td>
+                    <td class="prmNullFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmOptFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
               <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code><a>RTCQuicStreamParameters</a></code>
+                <em>Return type:</em> <code>void</code>
               </div>
             </dd>
+            <dt><dfn><code>abortWriting</code></dfn></dt>
+            <dd>
+              <p>A hard shutdown of the RTCQuicWritable stream. It may be called
+              regardless of whether the RTCQuicWritableStream object
+              was created by the local or remote peer. When the <code>abortWriting()</code>
+              method is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
+              run the following steps:</p>
+              <ol>
+                <li>Let <var>stream</var> be the RTCQuicWritableStream object
+                which is about to abort writing.</li>
+                <li>If <var>stream</var>'s <a>[[\Writable]]</a> slot is <code>false</code>,
+                <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</li>
+                <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to <code>false</code>.</li>
+                <li>Clear the <var>stream</var>'s write buffer.</li>
+                <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                which the <var>stream</var> was created from.
+                <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <li>Let <var>errorInfo</var> be the first argument.</li>
+                <li>Start the closing procedure by sending a RST_STREAM frame with its error
+                code set to the value of <var>errorInfo</var>.errorCode.</li>
+              </ol>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">errorInfo</td>
+                    <td class="prmType"><code>RTCQuicStreamAbortInfo</code></td>
+                    <td class="prmNullFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmOptFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt><dfn><code>waitForWriteBufferedAmountBelow</code></dfn></dt>
+            <dd>
+              <p><code>waitForWriteBufferedAmountBelow</code> <a>resolves</a> the promise when
+              the data queued in the write buffer falls below the given threshold.
+              If <code>waitForWriteBufferedAmountBelow</code>
+              is called multiple times, multiple promises could be resolved when the
+              write buffer falls below the threshold for each promise. The Promise will
+              be <a>rejected</a> with a newly created <code>InvalidStateError</code> if the
+              <var>stream</var>'s <a>[[\Writable]]</a> slot transitions from true to false
+              and the promise isn't <a>settled</a>. When the <code>waitForWriteBufferedAmountBelow</code> method
+              is called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em> run
+              the following steps:</p>
+              <ol>
+                <li>Let <var>stream</var> be the RTCQuicWritableStream
+                object on which <code>waitForWriteBufferedAmountBelow</code> was invoked.</li>
+                <li>Let <var>p</var> be a new promise.</li>
+                <li>If <var>stream</var>'s <a>[[\Writable]]</a> slot is
+                <code>false</code>, <a>reject</a> <var>p</var> with a
+                newly created <code>InvalidStateError</code> and abort
+                these steps.</li>
+                <li>Let <var>threshold</var> be the first argument.</li>
+                <li>When <var>stream</var>'s <a>[[\WriteBufferedAmount]]]</a> slot decreases
+                from above <var>threshold</var> to less than or equal to it,
+                <a>resolve</a> <var>p</var> with <code>undefined</code>.</li>
+              </ol>
+              <table class="parameters">
+                <tbody>
+                  <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th>Nullable</th>
+                    <th>Optional</th>
+                    <th>Description</th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">threshold</td>
+                    <td class="prmType"><code>unsigned long</code></td>
+                    <td class="prmNullFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmOptFalse"><span role="img" aria-label=
+                    "False">&#10008;</span></td>
+                    <td class="prmDesc"></td>
+                  </tr>
+                </tbody>
+              </table>
+              <div>
+                <em>Return type:</em> <code>Promise&lt;void&gt;</code>
+              </div>
+            </dd>
+        </dl>
+      </section>
+      </div>
+    </section>
+    <section id="rtcquicreadablestream-interface-mixin-definition*">
+      <h3>Interface Mixin <dfn>RTCQuicReadableStream</dfn></h3>
+      <div>
+        <pre class="idl">
+        [ Exposed=Window ]
+        interface mixin RTCQuicReadableStream {
+            readonly attribute boolean readable;
+            readonly attribute unsigned long readableAmount;
+            readonly attribute Promise&lt;RTCQuicStreamAbortInfo&gt; readingAborted;
+            RTCQuicStreamReadResult readInto (Uint8Array data);
+            void abortReading (RTCQuicStreamAbortInfo errorInfo);
+        };
+        </pre>
+        <section>
+          <h2>Overview</h2>
+          <p>The <code><a>RTCQuicReadableStream</a></code> will initialize with
+          the following:</p>
+          <ol>
+            <li>Let <var>stream</var> be the <code><a>RTCQuicReadableStream</a></code>.</li>
+            <li>Let <var>stream</var> have a <dfn>[[\Readable]]</dfn> internal
+            slot initialized to <code>true</code>.</li>
+            <li>Let <var>stream</var> have a <dfn>[[\ReadableAmount]]</dfn> internal
+            slot initialized to zero.</li>
+          </ol>
+        </section>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCQuicReadableStream" data-dfn-for="RTCQuicReadableStream" class=
+          "attributes">
+            <dt><code>readable</code> of type <span class="idlAttrType"><a>boolean</a></span>,
+            readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-rtcquicreadablestream-readableamount"><code>readable</code></dfn>
+              attribute represents whether data can be read from the <code><a>RTCQuicReadableStream</a></code>.
+              On getting, it <em class="rfc2119" title="MUST">MUST</em> return the value of the
+              RTCQuicReadableStream's <a>[[\Readable]]</a> slot.
+            </dd>
+            <dt><code>readableAmount</code> of type <span class="idlAttrType"><a>unsigned
+            long</a></span>, readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-rtcquicreadablestream-readableamount"><code>readableAmount</code></dfn>
+              attribute represents the number of bytes buffered for access by
+              <code>readInto</code> but that, as of the last time the event loop
+              started executing a task, had not yet been read. This does not include
+              framing overhead incurred by the protocol, or buffers associated with
+              the network hardware. On getting, it <em class="rfc2119" title="MUST">MUST</em>
+              return the value of the RTCQuicReadableStream's
+              <a>[[\ReadableAmount]]</a> internal slot.</p>
+            </dd>
+            <dt><code>readingAborted</code> of type <span class=idlAttriType"><a>RTCQuicStreamAbortInfo</a>
+            readonly</dt>
+            <dd>
+              <p>The <dfn id="dom-rtcquicreadablestream-readingAborted"><code>readingAborted</code></dfn>
+              attribute represents a promise that <a>resolves</a> when the
+              RST_STREAM frame is received from the <code><a>RTCQuicWritableStream</a></code>.
+              When the <var>stream</var> receives a RST_STREAM frame from its corresponding
+              <code><a>RTCQuicWritableStream</a></code>, the <a>user agent</a>
+              <em class="rfc2119" title="MUST">MUST</em> run the following:
+              <ol>
+                <li>Let <var>stream</var> be the <code><a>RTCQuicReadableStream</a></code>
+                object</li>
+                <li>Set <var>stream</var>'s <a>[[\Readable]]</a> slot to <code>false</code>.</li>
+                <li>Clear the <var>stream</var>'s read buffer.</li>
+                <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                which the <var>stream</var> was created from.
+                <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <li><a>resolve</a> the promise with the resulting
+                <code><a>RTCQuicStreamAbortInfo</a></code> with <code>errorCode</code>
+                set to the value of the errror code from the RST_STREAM frame.</li>
+              </ol>
+            </dd>
+          </dl>
+       </section>
+       <section>
+          <h2>Methods</h2>
+          <dl data-link-for="RTCQuicReadableStream" data-dfn-for="RTCQuicReadableStream" class=
+          "methods">
             <dt><dfn><code>readInto</code></dfn></dt>
             <dd>
-              <p>Reads from <code><a>RTCQuicStream</a></code> into the buffer specified
-              by the first argument and returns the number of bytes read; a negative
-              number indicates end-of-file. If there is no data to be read then
-              <code>readInto</code> returns zero. When the <code>readInto</code>
-              method is called, the user agent
+              <p>Reads from RTCQuicReadableStream into the buffer specified
+              by the first argument and returns <code><a>RTCQuicStreamReadResult</a></code>.
+              When the <code>readInto</code> method is called, the user agent
               <em class="rfc2119" title="MUST">MUST</em> run the following steps:</p>
               <ol>
-               <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code> object
+               <li>Let <var>stream</var> be the RTCQuicReadableStream object
                on which <code>readInto</code> is invoked.</li>
                <li>If <var>stream</var>'s <a>[[\Readable]]</a> slot is <code>false</code>,
                <a>throw</a> an <code>InvalidStateError</code>, then abort these steps.</li>
                <li>Let <var>data</var> be the first argument.</li>
-               <li>If <var>stream</var> has <a>finished reading</a> return
-               a negative number, set <var>stream</var>'s <a>[[\Readable]]</a> slot to
-               <code>false</code> and abort these steps.</li>
+               <li>Let <var>result</var> be the <code><a>RTCQuicStreamReadResult</a></code>
+               to be returned.</li>
+               <li>If <var>stream</var> has <a>finished reading</a>, return
+               <var>result</var> with <code>bytesRead</code> set to 0 and <code>finished</code> set to
+               <code>true</code> and abort these steps.</li>
                <li>Transfer data from the read buffer into <var>data</var>.</li>
                <li>Decrease the value of <var>stream</var>'s <a>[[\ReadableAmount]]</a>
                slot by the length of <var>data</var> in bytes.</li>
-               <li>Return the length of <var>data</var> in bytes.</li>
+               <li>Set <var>result</var>'s <code>bytesRead</code> to the size of
+               <var>data</var> in bytes.</li>
+               <li>If the <var>data</var> includes up to the FIN bit being read, then
+               run the following steps:</li>
+               <ol>
+                 <li>Set <var>result</var>'s <code>finished</code> to <code>true</code>.</li>
+                 <li>Set the <var>stream</var>'s <a>[[\Readable]]</a> slot to
+                 <code>false</code>.</li>
+                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                 which the <var>stream</var> was created from.
+                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                 <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+               </ol>
+               <li>Else, set <var>result</var>'s <code>finished</code> to false.</li>
+               <li>Return <var>result</var>.
               </ol>
               <table class="parameters">
                <tbody>
@@ -985,29 +1259,30 @@ interface RTCQuicStream {
                 </tbody>
               </table>
               <div>
-                <em>Return type:</em> <code>long</code>
+                <em>Return type:</em> <code><a>RTCQuicStreamReadResult</a></code>
               </div>
             </dd>
-            <dt><dfn><code>write</code></dfn></dt>
+            <dt><dfn><code>abortReading</code></dfn></dt>
             <dd>
-              <p>When the <code>write</code> method is called, the <a>user agent</a>
-              <em class="rfc2119" title="MUST">MUST</em> run the following steps:</p>
+              <p>A hard shutdown of the RTCQuicReadableStream. It may be called
+              regardless of whether the RTCQuicReadableStream object
+              was created by the local or remote peer. When the <code>abortReading()</code>
+              method is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
+              run the following steps:</p>
               <ol>
-               <li>Let <var>data</var> be the first argument.</li>
-               <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
-               object on which <var>data</var> is to be sent.</li>
-               <li>If <var>stream</var>'s <a>[[\Writable]]</a> slot is <code>false</code>,
-               <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</li>
-               <li>Increase the value of <var>stream</var>'s
-               <a>[[\WriteBufferedAmount]]</a> slot by the length of
-               <var>data</var> in bytes.</li>
-               <li>Queue <var>data</var> for transmission on <var>stream</var>'s
-               underlying data transport.
-               <div class="note">The actual transmission of data occurs in
-               parallel. If sending data leads to a QUIC-level error, the
-               application will be notified asynchronously through the
-               <code><a>RTCQuicTransport</a></code>'s <code><a>onerror</a></code>
-               EventHandler.</div></li>
+                <li>Let <var>stream</var> be the RTCQuicReadableStream object
+                which is about to abort reading.</li>
+                <li>If <var>stream</var>'s <a>[[\Readable]]</a> slot is <code>false</code>,
+                <a>throw</a> an <code>InvalidStateError</code> and abort these steps.</li>
+                <li>Set <var>stream</var>'s <a>[[\Readable]]</a> slot to <code>false</code>.</li>
+                <li>Clear the <var>stream</var>'s read buffer.</li>
+                <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                which the <var>stream</var> was created from.
+                <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <li>Let <var>errorInfo</var> be the first argument.</li>
+                <li>Start the closing procedure by sending a STOP_SENDING frame with its error
+                code set to the value of <var>errorInfo</var>.errorCode.</li>
               </ol>
               <table class="parameters">
                 <tbody>
@@ -1019,8 +1294,8 @@ interface RTCQuicStream {
                     <th>Description</th>
                   </tr>
                   <tr>
-                    <td class="prmName">data</td>
-                    <td class="prmType"><code>Uint8Array</code></td>
+                    <td class="prmName">errorInfo</td>
+                    <td class="prmType"><code>RTCQuicStreamAbortInfo</code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -1033,69 +1308,10 @@ interface RTCQuicStream {
                 <em>Return type:</em> <code>void</code>
               </div>
             </dd>
-            <dt><dfn><code>finish</code></dfn></dt>
-            <dd>
-              <p>Initiates the closing procedure for the
-              <code><a>RTCQuicStream</a></code>. It may be called
-              regardless of whether the <code><a>RTCQuicStream</a></code> object
-              was created by the local or remote peer. When the <code>finish()</code>
-              method is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
-              run the following steps:</p>
-              <ol>
-                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code> object
-                which is about to be closed.</li>
-                <li>If <var>stream</var>'s  <a>[[\State]]</a> is <code>"new"</code>,
-                set <var>stream</var>'s  <a>[[\State]]</a> to <code>"closed"</code>,
-                and abort these steps.</li>
-                <li>If <var>stream</var>'s  <a>[[\State]]</a> is <code>"closed"</code>,
-                then abort these steps.</li>
-                <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to <code>false</code>.</li>
-                <li>Set <var>stream</var>'s <a>[[\State]]</a> slot to
-                <code>"closing"</code>.</li>
-                <li>If <var>stream</var> has <a>finished reading</a>, set
-                <var>stream</var>'s <a>[[\State]]</a> slot to
-                <code>"closed"</code>.</li>
-                <li>If the closing procedure has not started yet, start it by sending a STREAM
-                frame with the FIN bit set.</li>
-              </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt><dfn><code>reset</code></dfn></dt>
-            <dd>
-              <p>Resets the <code><a>RTCQuicStream</a></code>. It may be called
-              regardless of whether the <code><a>RTCQuicStream</a></code> object
-              was created by the local or remote peer. When the <code>reset()</code>
-              method is called, the user agent <em class="rfc2119" title="MUST">MUST</em>
-              run the following steps:</p>
-              <ol>
-                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code> object
-                which is about to be reset.</li>
-                <li>If <var>stream</var>'s  <a>[[\State]]</a> is <code>"new"</code>,
-                set <var>stream</var>'s  <a>[[\State]]</a> to <code>"closed"</code>,
-                and abort these steps.</li>
-                <li>If <var>stream</var>'s  <a>[[\State]]</a> slot is <code>"closed"</code>,
-                then abort these steps.</li>
-                <li>Set <var>stream</var>'s <a>[[\State]]</a> slot to
-                <code>"closed"</code>.</li>
-                <li>If the closing procedure has not started yet, start it by sending a RST_STREAM
-                frame.</li>
-              </ol>
-              <div>
-                <em>No parameters.</em>
-              </div>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
            <dt><dfn><code>waitForReadable</code></dfn></dt>
             <dd>
               <p><code>waitForReadable</code> waits for data to become available, or
-              for the <code><a>RTCQuicStream</a></code> to be finished reading.  It
+              for the <code><a>RTCQuicReadableStream</a></code> to be finished reading.  It
               <a>resolves</a> the promise when the data queued in the read buffer
               increases above the amount provided as an argument or when a STREAM frame
               with the FIN bit set has been received. If <code>waitForReadable</code>
@@ -1107,7 +1323,7 @@ interface RTCQuicStream {
               called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em>
               run the following steps:</p>
               <ol>
-                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
+                <li>Let <var>stream</var> be the <code><a>RTCQuicReadableStream</a></code>
                 on which <code>waitForReadable</code> is invoked.</li>
                 <li>Let <var>p</var> be a new promise.</li>
                 <li>If <var>stream</var>'s <a>[[\Readable]]</a> slot is
@@ -1151,169 +1367,182 @@ interface RTCQuicStream {
                 <em>Return type:</em> <code>Promise&lt;void&gt;</code>
               </div>
             </dd>
-            <dt><dfn><code>waitForWriteBufferedAmountBelow</code></dfn></dt>
-            <dd>
-              <p><code>waitForWriteBufferedAmountBelow</code> <a>resolves</a> the promise when
-              the data queued in the write buffer falls below the given threshold.
-              If <code>waitForWriteBufferedAmountBelow</code>
-              is called multiple times, multiple promises could be resolved when the
-              write buffer falls below the threshold for each promise. The Promise will
-              be <a>rejected</a> with a newly created <code>InvalidStateError</code> if the
-              <var>stream</var>'s <a>[[\Writable]]</a> slot transitions from true to false
-              and the promise isn't <a>settled</a>. When the <code>waitForWriteBufferedAmountBelow</code> method
-              is called, the <a>user agent</a> <em class="rfc2119" title="MUST">MUST</em> run
-              the following steps:</p>
-              <ol>
-                <li>Let <var>stream</var> be the <code><a>RTCQuicStream</a></code>
-                object on which <code>waitForWriteBufferedAmountBelow</code> was invoked.</li>
-                <li>Let <var>p</var> be a new promise.</li>
-                <li>If <var>stream</var>'s <a>[[\Writable]]</a> slot is
-                <code>false</code>, <a>reject</a> <var>p</var> with a
-                newly created <code>InvalidStateError</code> and abort
-                these steps.</li>
-                <li>Let <var>threshold</var> be the first argument.</li>
-                <li>When <var>stream</var>'s <a>[[\WriteBufferedAmount]]]</a> slot decreases
-                from above <var>threshold</var> to less than or equal to it,
-                <a>resolve</a> <var>p</var> with <code>undefined</code>.</li>
-              </ol>
-              <table class="parameters">
-                <tbody>
-                  <tr>
-                    <th>Parameter</th>
-                    <th>Type</th>
-                    <th>Nullable</th>
-                    <th>Optional</th>
-                    <th>Description</th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">threshold</td>
-                    <td class="prmType"><code>unsigned long</code></td>
-                    <td class="prmNullFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmOptFalse"><span role="img" aria-label=
-                    "False">&#10008;</span></td>
-                    <td class="prmDesc"></td>
-                  </tr>
-                </tbody>
-              </table>
-              <div>
-                <em>Return type:</em> <code>Promise&lt;void&gt;</code>
-              </div>
-            </dd>
         </dl>
       </section>
       </div>
     </section>
-    <section id="rtcquicstreamstate*">
-      <h2><dfn>RTCQuicStreamState</dfn> Enum</h2>
-      <p>The <code>RTCQuicStreamState</code> provides information
-      on the state of the QUIC stream.</p>
+    <section id="rtcquicbidirectionalstream-interface-definition*">
+      <h3>Interface <dfn>RTCQuicBidirectionalStream</dfn></h3>
       <div>
-        <pre class="idl">enum RTCQuicStreamState {
-    "new",
-    "opening",
-    "open",
-    "closing",
-    "closed"
-};</pre>
-       <table data-link-for="RTCQuicStreamState" data-dfn-for="RTCQuicStreamState"
-        class="simple">
-          <tbody>
-            <tr>
-              <th colspan="2">Enumeration description</th>
-            </tr>
-            <tr>
-              <td><dfn><code id=
-              "idl-def-RTCQuicStreamState.new">new</code></dfn></td>
-              <td>
-                <p>The <a>user agent</a> has not yet attempted to
-                establish the underlying stream transport.  This is
-                the initial state of an <code><a>RTCQuicStream</a></code>
-                object, corresponding to the "idle" state in
-                [[QUIC-TRANSPORT]] Section 10.2.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id="idl-def-RTCQuicStreamState.opening">opening</code></dfn></td>
-              <td>
-                <p>The underlying QUIC stream has queued a STREAM frame for
-                transmission, but has not yet received an acknowledgement.
-                On transitioning to the <code>opening</code> state, the
-                <a>[[\Writable]]</a> slot is set to <code>true</code> if
-                the <a>[[\Direction]]</a> slot is set to <code>"send"</code>
-                or <code>"sendrecv"</code>.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id="idl-def-RTCQuicStreamState.open">open</code></dfn></td>
-              <td>
-                <p>The underlying QUIC stream has received a STREAM, MAX_STREAM_DATA or
-                STREAM_BLOCKED frame, or has sent a STREAM frame and received an acknowledgement,
-                as described in [[QUIC-TRANSPORT]] Section 10.2. This is the initial state of an
-                <code><a>RTCQuicStream</a></code> object dispatched as a part of an
-                <code>RTCQuicStreamEvent</code>. On transitioning to the <code>"open"</code>
-                state, the <a>[[\Readable]]</a> slot is set to <code>true</code> if
-                the <a>[[\Direction]]</a> slot is set to <code>"read"</code>
-                or <code>"sendrecv"</code>. The <a>[[\Writable]]</a> slot is set to
-                <code>true</code> if the <a>[[\Direction]]</a> slot is set to <code>"send"</code>
-                or <code>"sendrecv"</code>.</p>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id=
-              "idl-def-RTCQuicStreamState.closing">closing</code></dfn></td>
-              <td>
-                <p>The procedure to close down the <code><a>RTCQuicStream</a></code>
-                <var>stream</var> has started.
-                This can happen in multiple ways:</p>
-                  <ol>
-                     <li><var>stream</var> has not <a>finished reading</a> and the
-                     <code>finish</code> method has been called. This causes a
-                     STREAM frame with the FIN flag set to be queued for transmission,
-                     the write buffer to be cleared and <var>stream</var>'s
-                     <a>[[\Writable]]</a> slot to be set to <code>false</code>.</li>
-                     <li><var>stream</var> has <a>finished reading</a>. This causes
-                     <var>stream</var>'s <a>[[\Readable]]</a> slot to be set to
-                     <code>false</code>.</li>                     
-                  </ol>
-              </td>
-            </tr>
-            <tr>
-              <td><dfn><code id=
-              "idl-def-RTCQuicStreamState.closed">closed</code></dfn></td>
-              <td>
-                <p>The <code><a>RTCQuicStream</a></code> <var>stream</var> has been
-                closed or could not be established. This can happen in multiple ways:</p>
-                  <ol>
-                     <li>A RST_STREAM frame has been received.</li>
-                     <li>The <code>reset</code> method has been called.</li>
-                     <li>A STREAM frame with the FIN flag set has been sent
-                     and <var>stream</var> has <a>finished reading</a>.
-                     </li>
-                  </ol>
-                <p>On transitioning to the <code>closed</code> state, the user agent
-                <em class="rfc2119" title="MUST">MUST</em> run the following steps:</p>
-                  <ol>
-                    <li><a>[[\Readable]]</a> and <a>[[\Writable]]</a> slots are set to
-                    <code>false</code>.</li>
-                    <li>The <var>stream</var>'s read and write buffers are cleared.</li>
-                    <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
-                    which the <var>stream</var> was created from.
-                    <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                    <a>[[\QuicTransportStreams]]</a> internal slot.</li>
-                  </ol>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <pre class="idl">
+        [ Exposed=Window ]
+        interface RTCQuicBidirectionalStream {
+            readonly attribute unsigned long long streamId;
+            readonly attribute RTCQuicTransport transport;
+        };
+        RTCQuicBidirectionalStream includes RTCQuicWritableStream;
+        RTCQuicBidirectionalStream includes RTCQuicReadableStream;
+        </pre>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCQuicBidirectionalStream" data-dfn-for="RTCQuicBidirectionalStream" class=
+          "attributes">
+            <dt><dfn><code>streamId</code></dfn> of type <span class=
+            "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the ID of the
+              <code><a>RTCQuicBidirectionalStream</a></code> object.</p>
+            </dd>
+            <dt><dfn><code>transport</code></dfn> of type <span class=
+            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
+            </dd>
+          </dl>
+       </section>
       </div>
-      <figure>
-      <img alt="RTCQuicStreamState transition diagram" src=
-      "images/quicstream-state-revised.svg" style="width:50%">
-      <figcaption>
-        RTCQuicStreamState transition diagram
-      </figcaption>
-      </figure>
+    </section>
+    <section id="rtcquicsendstream-interface-definition*">
+      <h3>Interface <dfn>RTCQuicSendStream</dfn></h3>
+      <div>
+        <pre class="idl">
+        [ Exposed=Window ]
+        interface RTCQuicSendStream {
+            readonly attribute unsigned long long streamId;
+            readonly attribute RTCQuicTransport transport;
+        };
+        RTCQuicSendStream includes RTCQuicWritableStream;
+        </pre>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCQuicSendStream" data-dfn-for="RTCQuicSendStream" class=
+          "attributes">
+            <dt><dfn><code>streamId</code></dfn> of type <span class=
+            "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the ID of the
+              <code><a>RTCQuicSendStream</a></code> object.</p>
+            </dd>
+            <dt><dfn><code>transport</code></dfn> of type <span class=
+            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
+            </dd>
+          </dl>
+       </section>
+      </div>
+    </section>
+    <section id="rtcquicreceivestream-interface-definition*">
+      <h3>Interface <dfn>RTCQuicReceiveStream</dfn></h3>
+      <div>
+        <pre class="idl">
+        [ Exposed=Window ]
+        interface RTCQuicReceiveStream {
+            readonly attribute unsigned long long streamId;
+            readonly attribute RTCQuicTransport transport;
+        };
+        RTCQuicReceiveStream includes RTCQuicReadableStream;
+        </pre>
+        <section>
+          <h2>Attributes</h2>
+          <dl data-link-for="RTCQuicReceiveStream" data-dfn-for="RTCQuicReceiveStream" class=
+          "attributes">
+            <dt><dfn><code>streamId</code></dfn> of type <span class=
+            "idlAttrType"><a>unsigned long long</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the ID of the
+              <code><a>RTCQuicReadableStream</a></code> object.</p>
+            </dd>
+            <dt><dfn><code>transport</code></dfn> of type <span class=
+            "idlAttrType"><a>RTCQuicTransport</a></span>, readonly</dt>
+            <dd>
+              <p>The readonly attribute referring to the related <code><a>RTCQuicTransport</a></code> object.</p>
+            </dd>
+          </dl>
+       </section>
+      </div>
+    </section>
+    <section id="rtcquicstreamwriteparameters*">
+      <h3><dfn>RTCQuicStreamWriteParameters</dfn> Dictionary</h3>
+      <p>The <code>RTCQuicStreamWriteParameters</code> dictionary includes information
+      relating to the data to be written with <code><a>RTCQuicWritableStream</a>.write</code>.</p>
+      <div>
+        <pre class="idl">dictionary RTCQuicStreamWriteParameters {
+             Uint8Array data;
+             boolean finished = false;
+        };
+        </pre>
+        <section>
+          <h2>Dictionary <a class="idlType">RTCQuicStreamWriteParameters</a> Members</h2>
+          <dl data-link-for="RTCQuicStreamWriteParameters" data-dfn-for="RTCQuicStreamWriteParameters" class=
+          "dictionary-members">
+            <dt><dfn><code>data</code></dfn> of type <span class=
+            "idlMemberType"><a>Uint8Array</a></span>.</dt>
+            <dd>
+              <p>The data to be written.</p>
+            </dd>
+            <dt><dfn><code>finished</code></dfn> of type <span class=
+            "idlMemberType">boolean</span>.</dt>
+            <dd>
+              <p>Set to <code>true</code> if this is the last data to be written.
+              This will result in a STREAM frame with the FIN bit set.</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="rtcquicstreamresult*">
+      <h3><dfn>RTCQuicStreamReadResult</dfn> Dictionary</h3>
+      <p>The <code>RTCQuicStreamReadResult</code> dictionary includes information
+      relating to the result returned from <code>readInto</code>.</p>
+      <div>
+        <pre class="idl">dictionary RTCQuicStreamReadResult {
+             unsigned long bytesRead;
+             boolean finished = false;
+        };
+        </pre>
+        <section>
+          <h2>Dictionary <a class="idlType">RTCQuicStreamReadResult</a> Members</h2>
+          <dl data-link-for="RTCQuicStreamReadResult" data-dfn-for="RTCQuicStreamReadResult" class=
+          "dictionary-members">
+            <dt><dfn><code>bytesRead</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned long</a></span>.</dt>
+            <dd>
+              <p>The amount of data read in bytes.</p>
+            </dd>
+            <dt><dfn><code>finished</code></dfn> of type <span class=
+            "idlMemberType">boolean</span>.</dt>
+            <dd>
+              <p>Set to <code>true</code> if the RTCQuicReadableStream has
+              <a>finished reading</a>.</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="rtcquicstreamabortinfo*">
+      <h3><dfn>RTCQuicStreamAbortInfo</dfn> Dictionary</h3>
+      <p>The <code>RTCQuicStreamAbortInfo</code> dictionary includes information
+      relating to the error code for aborting a QUIC stream. This could be used either
+      in a RST_STREAM frame or STOP_SENDING frame.</p>
+      <div>
+        <pre class="idl">dictionary RTCQuicStreamAbortInfo {
+             unsigned short errorCode = 0;
+        };
+        </pre>
+        <section>
+          <h2>Dictionary <a class="idlType">RTCQuicStreamAbortInfo</a> Members</h2>
+          <dl data-link-for="RTCQuicStreamAbortInfo" data-dfn-for="RTCQuicStreamAbortInfo" class=
+          "dictionary-members">
+            <dt><dfn><code>errorCode</code></dfn> of type <span class=
+            "idlMemberType"><a>unsigned short</a></span>.</dt>
+            <dd>
+              <p>The error code used in the RST_STREAM or STOP_SENDING frame.
+              The default value of 0 means "STOPPING."</p>
+            </dd>
+          </dl>
+        </section>
+      </div>
     </section>
   </section>
     <section id="privacy-security">
@@ -1398,30 +1627,24 @@ interface RTCQuicStream {
           <td>The <code><a>RTCQuicTransportState</a></code> changed.</td>
         </tr>
         <tr>
-          <td><dfn><code>quicstream</code></dfn></td>
-          <td><code><a>RTCQuicStreamEvent</a></code></td>
-          <td>A new <code><a>RTCQuicStream</a></code> is dispatched to the script in
-          response to the remote peer creating a QUIC stream. Prior to
-          <code><a>quicstream</a></code> firing, the <code><a>RTCQuicStream</a></code>
-          is added to <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
+          <td><dfn><code>newreceivestreamwithdata</code></dfn></td>
+          <td><code><a>NewReceiveStreamWithDataEvent</a></code></td>
+          <td>A new <code><a>RTCQuicReceiveStream</a></code> is dispatched to the
+          script in response to the remote peer creating a send only QUIC stream and
+          sending data on it. Prior to <code><a>newreceivestreamwithdata</a></code>
+          firing, the <code><a>RTCQuicReceiveStream</a></code> is added to
+          <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
           internal slot.</td>
         </tr>
-      </tbody>
-    </table>
-    <p>The following events fire on <code><a>RTCQuicStream</a></code> objects:</p>
-    <table style="border-width:0; width:60%" border="1">
-      <tbody>
         <tr>
-          <th>Event name</th>
-          <th>Interface</th>
-          <th>Fired when...</th>
-        </tr>
-      </tbody>
-      <tbody>
-        <tr>
-          <td><code>statechange</code></td>
-          <td><code><a>Event</a></code></td>
-          <td>The <code><a>RTCQuicStreamState</a></code> changed.</td>
+          <td><dfn><code>newbidirectionalstreamwithdata</code></dfn></td>
+          <td><code><a>NewBidirectionalStreamWithDataEvent</a></code></td>
+          <td>A new <code><a>RTCQuicBidirectionalStream</a></code> is dispatched to the
+          script in response to the remote peer creating a bidirectional QUIC stream and
+          sending data on it. Prior to <code><a>newbidirectionalstreamwithdata</a></code>
+          firing, the <code><a>RTCQuicBidirectionalStream</a></code> is added to
+          <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
+          internal slot.</td>
         </tr>
       </tbody>
     </table>
@@ -1441,7 +1664,7 @@ interface RTCQuicStream {
     Harald Alvestrand, Stefan H&aring;kansson, Bernard Aboba and Dominique
     Haza&euml;l-Massieux, for their support. Contributions to this
     specification were provided by Robin Raymond.</p>
-    <p>The <code><a>RTCQuicTransport</a></code> and <code><a>RTCQuicStream</a></code> objects
+    <p>The <code><a>RTCQuicTransport</a></code> and <code>RTCQuicStream</code> objects
     were initially described in the <a href="https://www.w3.org/community/ortc/">W3C ORTC CG</a>,
     and have been adapted for use in this specification.</p>
  </section>

--- a/index.html
+++ b/index.html
@@ -173,9 +173,13 @@ interface RTCQuicTransport : RTCStatsProvider {
               Let <var>quictransport</var> be a newly constructed
               <code><a>RTCQuicTransport</a></code> object.
             </li>
-            <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportStreams]]</dfn>
-            internal slot representing a sequence of (<code><a>RTCQuicWritableStream</a></code>
-            or <code><a>RTCQuicReadableStream</a></code>) objects, initialized to empty.
+            <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportWritableStreams]]</dfn>
+            internal slot representing a sequence of <code><a>RTCQuicWritableStream</a></code>
+            objects, initialized to empty.
+            </li>
+            <li>Let <var>quictransport</var> have a <dfn>[[\QuicTransportReadableStreams]]</dfn>
+            internal slot representing a sequence of <code><a>RTCQuicReadableStream</a></code>
+            objects, initialized to empty.
             </li>
             <li>
               Let <var>quictransport</var> have a <dfn>[[\QuicTransportState]]</dfn>
@@ -438,8 +442,12 @@ interface RTCQuicTransport : RTCStatsProvider {
                   <code><a>RTCQuicBidirectionalStream</a></code> object.</p>
                 </li>
                 <li>
-                  <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
-                  internal slot. </p>
+                  <p>Add <var>stream</var> to <var>transport</var>'s
+                  <a>[[\QuicTransportWritableStreams]]</a> internal slot. </p>
+                </li>
+                <li>
+                  <p>Add <var>stream</var> to <var>transport</var>'s
+                  <a>[[\QuicTransportReadableStreams]]</a> internal slot. </p>
                 </li>
                 <li>
                   <p>Return <var>stream</var> and continue the following steps
@@ -480,7 +488,7 @@ interface RTCQuicTransport : RTCStatsProvider {
                   <code><a>RTCQuicSendStream</a></code> object.</p>
                 </li>
                 <li>
-                  <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportStreams]]</a>
+                  <p>Add <var>stream</var> to <var>transport</var>'s <a>[[\QuicTransportWritableStreams]]</a>
                   internal slot. </p>
                 </li>
                 <li>
@@ -825,24 +833,26 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 <ol>
                   <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>.
                   <li>For each RTCQuicReadableStream in <var>transport</var>'s
-                  <a>[[\QuicTransportStreams]]</a> internal slot run the following:</li>
+                  <a>[[\QuicTransportReadableStreams]]</a> internal slot run the
+                  following:</li>
                   <ol>
                     <li>Let <var>stream</var> be the RTCQuicReadableStream.</li>
                     <li>Set <var>stream</var>'s <a>[[\Readable]]</a> slot to
                     <code>false</code>.</li>
                     <li>Clear the <var>stream</var>'s read buffer.</li>
                     <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                    <a>[[\QuicTransportStreams]]</a> internal slot.
+                    <a>[[\QuicTransportReadableStreams]]</a> internal slot.
                   </ol>
                   <li>For each RTCQuicWritableStream in <var>transport</var>'s
-                  <a>[[\QuicTransportStreams]]</a> internal slot run the following:</li>
+                  <a>[[\QuicTransportWritableStreams]]</a> internal slot run the
+                  following:</li>
                   <ol>
                     <li>Let <var>stream</var> be the RTCQuicWritableStream.</li>
                     <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to
                     <code>false</code>.</li>
                     <li>Clear the <var>stream</var>'s write buffer.</li>
                     <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                    <a>[[\QuicTransportStreams]]</a> internal slot.
+                    <a>[[\QuicTransportWritableStreams]]</a> internal slot.
                   </ol>
                 </ol>
               </td>
@@ -962,7 +972,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
                 which the <var>stream</var> was created from.
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <a>[[\QuicTransportWritableStreams]]</a> internal slot.</li>
                 <li><a>resolve</a> the promise with the resulting
                 <code><a>RTCQuicStreamAbortInfo</a></code> with the <code>errorCode</code>
                 set to the value from the STOP_SENDING frame.</li>
@@ -995,13 +1005,22 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                <var>data</var>.data in bytes.</li>
                <li>Queue <var>data</var>.data for transmission on <var>stream</var>'s
                underlying data transport.</li>
-               <li>Queue a STREAM frame with the FIN bit set if <var>data</var>.finish
-               is set to <code>true</code>.
+               <li>if <var>data</var>.finish is set to <code>true</code>, run the
+               following:</li>
+               <ol>
+                 <li>Queue a STREAM frame with the FIN bit set.</li>
+                 <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to
+                 <code>false</code>.</li>
+                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
+                 which the <var>stream</var> was created from.</li>
+                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
+                 <a>[[\QuicTransportWritableStreams]]</a> internal slot.</li>
+               </ol>
                <div class="note">The actual transmission of data occurs in
                parallel. If sending data leads to a QUIC-level error, the
                application will be notified asynchronously through the
                <code><a>RTCQuicTransport</a></code>'s <code><a>onerror</a></code>
-               EventHandler.</div></li>
+               EventHandler.</div>
               </ol>
               <table class="parameters">
                 <tbody>
@@ -1042,9 +1061,9 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 <li>Set <var>stream</var>'s <a>[[\Writable]]</a> slot to <code>false</code>.</li>
                 <li>Clear the <var>stream</var>'s write buffer.</li>
                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
-                which the <var>stream</var> was created from.
+                which the <var>stream</var> was created from.</li>
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <a>[[\QuicTransportWritableStreams]]</a> internal slot.</li>
                 <li>Let <var>abortInfo</var> be the first argument.</li>
                 <li>Start the closing procedure by sending a RST_STREAM frame with its error
                 code set to the value of <var>abortInfo</var>.errorCode.</li>
@@ -1192,7 +1211,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
                 which the <var>stream</var> was created from.
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <a>[[\QuicTransportReadableStreams]]</a> internal slot.</li>
                 <li><a>resolve</a> the promise with the resulting
                 <code><a>RTCQuicStreamAbortInfo</a></code> with <code>errorCode</code>
                 set to the value of the errror code from the RST_STREAM frame.</li>
@@ -1235,7 +1254,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                  <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
                  which the <var>stream</var> was created from.
                  <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                 <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                 <a>[[\QuicTransportReadableStreams]]</a> internal slot.</li>
                </ol>
                <li>Else, set <var>result</var>'s <code>finished</code> to false.</li>
                <li>Return <var>result</var>.
@@ -1281,7 +1300,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
                 <li>Let <var>transport</var> be the <code><a>RTCQuicTransport</a></code>,
                 which the <var>stream</var> was created from.
                 <li>Remove the <var>stream</var> from the <var>transport</var>'s
-                <a>[[\QuicTransportStreams]]</a> internal slot.</li>
+                <a>[[\QuicTransportReadableStreams]]</a> internal slot.</li>
                 <li>Let <var>abortInfo</var> be the first argument.</li>
                 <li>Start the closing procedure by sending a STOP_SENDING frame with its error
                 code set to the value of <var>abortInfo</var>.errorCode.</li>
@@ -1607,7 +1626,7 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           script in response to the remote peer creating a send only QUIC stream and
           sending data on it. Prior to <code><a>newreceivestreamwithdata</a></code>
           firing, the <code><a>RTCQuicReceiveStream</a></code> is added to
-          <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
+          <code><a>RTCQuicTransport</a></code>'s<a>[[\QuicTransportReadableStreams]]</a>
           internal slot.</td>
         </tr>
         <tr>
@@ -1616,9 +1635,9 @@ interface NewBidirectionalStreamWithDataEvent : Event {
           <td>A new <code><a>RTCQuicBidirectionalStream</a></code> is dispatched to the
           script in response to the remote peer creating a bidirectional QUIC stream and
           sending data on it. Prior to <code><a>newbidirectionalstreamwithdata</a></code>
-          firing, the <code><a>RTCQuicBidirectionalStream</a></code> is added to
-          <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportStreams]]</a>
-          internal slot.</td>
+          firing, the <code><a>RTCQuicBidirectionalStream</a></code> is added to both the
+          <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportReadableStreams]]</a>
+          and <a>[[\QuicTransportWritableStreams]]</a> internal slot.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
This is a large change, as discussed in issue [69](https://github.com/w3c/webrtc-quic/issues/69) & prototyped in this [doc](https://docs.google.com/document/d/1kPOJxYsoOKmFJlztN7LbKaitiswRFRbgzswefOxCfuE/edit).

To view refer to this page:
https://rawgit.com/w3c/webrtc-quic/unidirectional-streams-and-state-update/index.html

I think this is a good starting point. Feel free to make commits to this. My hope is that we can get this change in quickly, then iterate on it with further details/issues.

Issues that can be closed after this PR goes through:
- [50](https://github.com/w3c/webrtc-quic/issues/50) - restricting createStream to state = connected
- [54](https://github.com/w3c/webrtc-quic/issues/54) - new/open/opening for a stream
- [55](https://github.com/w3c/webrtc-quic/issues/55) - remote stream triggering with data sent
- [61](https://github.com/w3c/webrtc-quic/issues/61) - Reset/STOP_SENDING
- [64](https://github.com/w3c/webrtc-quic/issues/64) - readable/writable access
- [65](https://github.com/w3c/webrtc-quic/issues/65) - Taking out RTCQuicStreamState