### PR TITLE
Add support for unreliability (with parameters dictionary) 

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,7 @@
     <p>While this specification defines an interface to QUIC streams,
     by utilizing a QUIC stream per message, it is possible to implement
     support for message-based communications (such as <code>RTCDataChannel</code>)
-    on top.  While the QUIC transport defined in [[!QUIC-TRANSPORT]] is reliable,
-    support for unreliable communications is achievable via use of timers or
-    through future extensions to the QUIC protocol.</p>
-  </section>
+    on top.</p>  </section>
   <section id="conformance">
     <p>This specification defines conformance criteria that apply to a single
     product: the <dfn>user agent</dfn> that implements the interfaces that it
@@ -421,10 +418,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             </dd>
            <dt><dfn><code>createBidirectionalStream</code></dfn></dt>
             <dd>
-              <p>Creates an <code><a>RTCQuicBidirectionalStream</a></code> object.
-              Since [[QUIC-TRANSPORT]] only defines reliable QUIC streams,
-              <code>createBidectionalStream</code> only supports creation of reliable
-              streams.</p>
+              <p>Creates an <code><a>RTCQuicBidirectionalStream</a></code> object.</p>
               <p>When <code>createBidectionalStream</code> is called, the user agent
               <em class="rfc2119" title="MUST">MUST</em> run the following
               steps:</p>
@@ -467,10 +461,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             </dd>
            <dt><dfn><code>createSendStream</code></dfn></dt>
             <dd>
-              <p>Creates an <code><a>RTCQuicSendStream</a></code> object.
-              Since [[QUIC-TRANSPORT]] only defines reliable QUIC streams,
-              <code>createSendStream</code> only supports creation of reliable
-              streams.</p>
+              <p>Creates an <code><a>RTCQuicSendStream</a></code> object.</p>
               <p>When <code>createSendStream</code> is called, the user agent
               <em class="rfc2119" title="MUST">MUST</em> run the following
               steps:</p>
@@ -548,19 +539,19 @@ interface RTCQuicTransport : RTCStatsProvider {
       relating to QUIC stream configuration.</p>
       <div>
         <pre class="idl">dictionary RTCQuicStreamParameters {
-             bool reliable = true;
+             bool disableRetransmissions = false;
 };</pre>
         <section>
           <h2>Dictionary <a class="idlType">RTCQuicStreamParameters</a> Members</h2>
           <dl data-link-for="RTCQuicStreamParameters" data-dfn-for="RTCQuicStreamParameters" class=
           "dictionary-members">
-            <dt><dfn><code>reliable</code></dfn> of type <span class=
+            <dt><dfn><code>disableRetransmissions</code></dfn> of type <span class=
             "idlMemberType"><a>bool</a></span>, defaulting to
-            <code>true</code></dt>
+            <code>false</code></dt>
             <dd>
-              <p>Reliable, with a default of <code>true</code>.  If
-              true, the stream will be sent reliably.  If not, the
-              stream will be sent unreliably.</p>
+              <p>disableRetransmissions, with a default of <code>false</code>.  If
+              true, the stream will be sent without retransmissions.  If false, the
+              stream will be sent with retransmissions.</p>
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@ interface RTCQuicTransport : RTCStatsProvider {
     void                  start (RTCQuicParameters remoteParameters);
     void                  stop ();
     RTCQuicBidirectionalStream         createBidirectionalStream ();
-    RTCQuicSendStream                  createSendStream ();
+    RTCQuicSendStream                  createSendStream (optional RTCQuicStreamParameters parameters);
                     attribute EventHandler             onstatechange;
                     attribute EventHandler             onerror;
                     attribute EventHandler             onreceivestreamwithdata;
@@ -538,6 +538,30 @@ interface RTCQuicTransport : RTCStatsProvider {
               (with one computed with the digest algorithm used in the certificate
               signature).</p>
             </dd> 
+          </dl>
+        </section>
+      </div>
+    </section>
+    <section id="rtcstreamparameters*">
+      <h3><dfn>RTCQuicStreamParameters</dfn> Dictionary</h3>
+      <p>The <code>RTCQuicParameters</code> dictionary includes information
+      relating to QUIC stream configuration.</p>
+      <div>
+        <pre class="idl">dictionary RTCQuicStreamParameters {
+             bool reliable = true;
+};</pre>
+        <section>
+          <h2>Dictionary <a class="idlType">RTCQuicStreamParameters</a> Members</h2>
+          <dl data-link-for="RTCQuicStreamParameters" data-dfn-for="RTCQuicStreamParameters" class=
+          "dictionary-members">
+            <dt><dfn><code>reliable</code></dfn> of type <span class=
+            "idlMemberType"><a>bool</a></span>, defaulting to
+            <code>true</code></dt>
+            <dd>
+              <p>Reliable, with a default of <code>true</code>.  If
+              true, the stream will be sent reliably.  If not, the
+              stream will be sent unreliably.</p>
+            </dd>
           </dl>
         </section>
       </div>

--- a/index.html
+++ b/index.html
@@ -1688,7 +1688,15 @@ interface BidirectionalStreamWithDataEvent : Event {
   </section>
  <section class="informative" id="examples*">
     <h2>Examples</h2>
+    <h3>Unreliable delivery</h3>
+    <p>Unreliable delivery can be achieved by creating many small streams
+    (treated each as a single small message) with restranmissions disabled.</p>
       <pre class="example highlight">
+let quic = getQuicTransport();
+let messages = getMessages();
+for (msg in messages) {
+  quic.createSendStream({disableRetransmissions: true}).write({data: msg, finished: true});
+}
       </pre>
  </section>
  <section id="change-log*">


### PR DESCRIPTION
Via a dictionary with RTCQuicStreamParameters.reliable passed to createSendStream.