### PR TITLE
Remove "withdata" from events

### DIFF
--- a/index.html
+++ b/index.html
@@ -984,7 +984,7 @@ interface BidirectionalStreamEvent : Event {
       following ways:</p>
       <ol>
         <li>Using the <code><a>RTCQuicTransport</a>.createBidirectionalStream</code></li>
-        <li>Getting a <code><a>bidirectionalstreamwithdata</a></code> event on the
+        <li>Getting a <code><a>bidirectionalstreamw</a></code> event on the
         <code><a>RTCQuicTransport</a></code></li>
       </ol>
       <p>A <code><a>RTCQuicSendStream</a></code> can be created in the following
@@ -995,7 +995,7 @@ interface BidirectionalStreamEvent : Event {
       <p>A <code><a>RTCQuicReceiveStream</a></code> can be created in the following
       ways:</p>
       <ol>
-        <li>Getting a <code><a>receivestreamwithdata</a></code> event on the
+        <li>Getting a <code><a>receivestream</a></code> event on the
         <code><a>RTCQuicTransport</a></code></li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>bidirectionalstream</a></code>,
+              <code><a>bidirectionalstreamwithdata</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.

--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>bidirectionalstreamwithdata</a></code>,
+              <code><a>bidirectionalstream</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.

--- a/index.html
+++ b/index.html
@@ -984,7 +984,7 @@ interface BidirectionalStreamEvent : Event {
       following ways:</p>
       <ol>
         <li>Using the <code><a>RTCQuicTransport</a>.createBidirectionalStream</code></li>
-        <li>Getting a <code><a>bidirectionalstreamw</a></code> event on the
+        <li>Getting a <code><a>bidirectionalstream</a></code> event on the
         <code><a>RTCQuicTransport</a></code></li>
       </ol>
       <p>A <code><a>RTCQuicSendStream</a></code> can be created in the following

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             <dd>
               <p>This event handler, of event handler event type
               <code><a>bidirectionalstream</a></code>,
-              <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
+              <em class="rfc2119" title="MUST">MUST</em> be fired when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.
               </p>

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@ interface RTCQuicTransport : RTCStatsProvider {
             <dd>
               <p>This event handler, of event handler event type
               <code><a>bidirectionalstream</a></code>,
-              <em class="rfc2119" title="MUST">MUST</em> be fired on when when data is received
+              <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.
               </p>

--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@ interface RTCQuicTransport : RTCStatsProvider {
     RTCQuicSendStream                  createSendStream (optional RTCQuicStreamParameters parameters);
                     attribute EventHandler             onstatechange;
                     attribute EventHandler             onerror;
-                    attribute EventHandler             onreceivestreamwithdata;
-                    attribute EventHandler             onbidirectionalstreamwithdata;
+                    attribute EventHandler             onreceivestream;
+                    attribute EventHandler             onbidirectionalstream;
 };</pre>
         <section>
           <h2>Constructors</h2>
@@ -269,21 +269,21 @@ interface RTCQuicTransport : RTCStatsProvider {
               "SHOULD">SHOULD</em> include QUIC error information in
               <var>error.message</var> (defined in [[!HTML51]] Section 7.1.3.8.2).</p>
             </dd>
-            <dt><dfn><code>onreceivestreamwithdata</code></dfn> of type <span class=
+            <dt><dfn><code>onreceivestream</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>receivestreamwithdata</a></code>,
+              <code><a>receivestream</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when data is received
               from a newly created remote <code><a>RTCQuicSendStream</a></code> for the
               first time.
               </p>
             </dd>
-            <dt><dfn><code>onbidirectionalstreamwithdata</code></dfn> of type <span class=
+            <dt><dfn><code>onbidirectionalstream</code></dfn> of type <span class=
             "idlAttrType"><a>EventHandler</a></span></dt>
             <dd>
               <p>This event handler, of event handler event type
-              <code><a>bidirectionalstreamwithdata</a></code>,
+              <code><a>bidirectionalstream</a></code>,
               <em class="rfc2119" title="MUST">MUST</em> be fired on when when data is received
               from a newly created remote <code><a>RTCQuicBidirectionalStream</a></code> for the
               first time.
@@ -581,20 +581,20 @@ interface RTCQuicTransport : RTCStatsProvider {
       </div>
     </section>
     <section>
-      <h3><dfn>ReceiveStreamWithDataEvent</dfn></h3>
-      <p>The <code><a>receivestreamwithdata</a></code> event uses the
-      <code><a>ReceiveStreamWithDataEvent</a></code> interface.</p>
+      <h3><dfn>ReceiveStreamEvent</dfn></h3>
+      <p>The <code><a>receivestream</a></code> event uses the
+      <code><a>ReceiveStreamEvent</a></code> interface.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, ReceiveStreamWithDataEventInit eventInitDict), Exposed=Window]
-interface ReceiveStreamWithDataEvent : Event {
+        [ Constructor (DOMString type, ReceiveStreamEventInit eventInitDict), Exposed=Window]
+interface ReceiveStreamEvent : Event {
     readonly        attribute RTCQuicReceiveStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="ReceiveStreamWithDataEvent" data-dfn-for="ReceiveStreamWithDataEvent"
+          <dl data-link-for="ReceiveStreamEvent" data-dfn-for="ReceiveStreamEvent"
           class="constructors">
-            <dt><code>ReceiveStreamWithDataEvent</code></dt>
+            <dt><code>ReceiveStreamEvent</code></dt>
             <dd>
               <table class="parameters">
                 <tbody>
@@ -616,7 +616,7 @@ interface ReceiveStreamWithDataEvent : Event {
                   </tr>
                   <tr>
                     <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>ReceiveStreamWithDataEventInit</a></code></td>
+                    <td class="prmType"><code><a>ReceiveStreamEventInit</a></code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -630,7 +630,7 @@ interface ReceiveStreamWithDataEvent : Event {
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="ReceiveStreamWithDataEvent" data-dfn-for="ReceiveStreamWithDataEvent"
+          <dl data-link-for="ReceiveStreamEvent" data-dfn-for="ReceiveStreamEvent"
           class="attributes">
             <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicReceiveStream</a></span>, readonly</dt>
@@ -643,15 +643,15 @@ interface ReceiveStreamWithDataEvent : Event {
         </section>
       </div>
       <div>
-          <p>The <dfn><code>ReceiveStreamWithDataEventInit</code></dfn> dictionary includes
+          <p>The <dfn><code>ReceiveStreamEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary ReceiveStreamWithDataEventInit : EventInit {
+        <pre class="idl">dictionary ReceiveStreamEventInit : EventInit {
              RTCQuicReceiveStream stream;
 };</pre>
         <section>
-          <h2>Dictionary ReceiveStreamWithDataEventInit Members</h2>
-          <dl data-link-for="ReceiveStreamWithDataEventInit" data-dfn-for=
-          "ReceiveStreamWithDataEventInit" class="dictionary-members">
+          <h2>Dictionary ReceiveStreamEventInit Members</h2>
+          <dl data-link-for="ReceiveStreamEventInit" data-dfn-for=
+          "ReceiveStreamEventInit" class="dictionary-members">
             <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicReceiveStream</a></span></dt>
             <dd>
@@ -663,20 +663,20 @@ interface ReceiveStreamWithDataEvent : Event {
       </div>
     </section>
     <section>
-      <h3><dfn>BidirectionalStreamWithDataEvent</dfn></h3>
-      <p>The <code><a>bidirectionalstreamwithdata</a></code> event uses the
-      <code><a>BidirectionalStreamWithDataEvent</a></code> interface.</p>
+      <h3><dfn>BidirectionalStreamEvent</dfn></h3>
+      <p>The <code><a>bidirectionalstream</a></code> event uses the
+      <code><a>BidirectionalStreamEvent</a></code> interface.</p>
       <div>
         <pre class="idl">
-        [ Constructor (DOMString type, BidirectionalStreamWithDataEventInit eventInitDict), Exposed=Window]
-interface BidirectionalStreamWithDataEvent : Event {
+        [ Constructor (DOMString type, BidirectionalStreamEventInit eventInitDict), Exposed=Window]
+interface BidirectionalStreamEvent : Event {
     readonly        attribute RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
           <h2>Constructors</h2>
-          <dl data-link-for="BidirectionalStreamWithDataEvent" data-dfn-for="BidirectionalStreamWithDataEvent"
+          <dl data-link-for="BidirectionalStreamEvent" data-dfn-for="BidirectionalStreamEvent"
           class="constructors">
-            <dt><code>BidirectionalStreamWithDataEvent</code></dt>
+            <dt><code>BidirectionalStreamEvent</code></dt>
             <dd>
               <table class="parameters">
                 <tbody>
@@ -698,7 +698,7 @@ interface BidirectionalStreamWithDataEvent : Event {
                   </tr>
                   <tr>
                     <td class="prmName">eventInitDict</td>
-                    <td class="prmType"><code><a>BidirectionalStreamWithDataEventInit</a></code></td>
+                    <td class="prmType"><code><a>BidirectionalStreamEventInit</a></code></td>
                     <td class="prmNullFalse"><span role="img" aria-label=
                     "False">&#10008;</span></td>
                     <td class="prmOptFalse"><span role="img" aria-label=
@@ -712,7 +712,7 @@ interface BidirectionalStreamWithDataEvent : Event {
         </section>
         <section>
           <h2>Attributes</h2>
-          <dl data-link-for="BidirectionalStreamWithDataEvent" data-dfn-for="BidirectionalStreamWithDataEvent"
+          <dl data-link-for="BidirectionalStreamEvent" data-dfn-for="BidirectionalStreamEvent"
           class="attributes">
             <dt><code>stream</code> of type <span class=
             "idlAttrType"><a>RTCQuicBidirectionalStream</a></span>, readonly</dt>
@@ -725,15 +725,15 @@ interface BidirectionalStreamWithDataEvent : Event {
         </section>
       </div>
       <div>
-          <p>The <dfn><code>BidirectionalStreamWithDataEventInit</code></dfn> dictionary includes
+          <p>The <dfn><code>BidirectionalStreamEventInit</code></dfn> dictionary includes
           information on the configuration of the QUIC stream.</p>
-        <pre class="idl">dictionary BidirectionalStreamWithDataEventInit : EventInit {
+        <pre class="idl">dictionary BidirectionalStreamEventInit : EventInit {
              RTCQuicBidirectionalStream stream;
 };</pre>
         <section>
-          <h2>Dictionary BidirectionalStreamWithDataEventInit Members</h2>
-          <dl data-link-for="BidirectionalStreamWithDataEventInit" data-dfn-for=
-          "BidirectionalStreamWithDataEventInit" class="dictionary-members">
+          <h2>Dictionary BidirectionalStreamEventInit Members</h2>
+          <dl data-link-for="BidirectionalStreamEventInit" data-dfn-for=
+          "BidirectionalStreamEventInit" class="dictionary-members">
             <dt><dfn><code>stream</code></dfn> of type <span class=
             "idlMemberType"><a>RTCQuicBidirectionalStream</a></span></dt>
             <dd>
@@ -1718,21 +1718,21 @@ interface BidirectionalStreamWithDataEvent : Event {
           <td>The <code><a>RTCQuicTransportState</a></code> changed.</td>
         </tr>
         <tr>
-          <td><dfn><code>receivestreamwithdata</code></dfn></td>
-          <td><code><a>ReceiveStreamWithDataEvent</a></code></td>
+          <td><dfn><code>receivestream</code></dfn></td>
+          <td><code><a>ReceiveStreamEvent</a></code></td>
           <td>A new <code><a>RTCQuicReceiveStream</a></code> is dispatched to the
           script in response to the remote peer creating a send only QUIC stream and
-          sending data on it. Prior to <code><a>receivestreamwithdata</a></code>
+          sending data on it. Prior to <code><a>receivestream</a></code>
           firing, the <code><a>RTCQuicReceiveStream</a></code> is added to
           <code><a>RTCQuicTransport</a></code>'s<a>[[\QuicTransportReadableStreams]]</a>
           internal slot.</td>
         </tr>
         <tr>
-          <td><dfn><code>bidirectionalstreamwithdata</code></dfn></td>
-          <td><code><a>BidirectionalStreamWithDataEvent</a></code></td>
+          <td><dfn><code>bidirectionalstream</code></dfn></td>
+          <td><code><a>BidirectionalStreamEvent</a></code></td>
           <td>A new <code><a>RTCQuicBidirectionalStream</a></code> is dispatched to the
           script in response to the remote peer creating a bidirectional QUIC stream and
-          sending data on it. Prior to <code><a>bidirectionalstreamwithdata</a></code>
+          sending data on it. Prior to <code><a>bidirectionalstream</a></code>
           firing, the <code><a>RTCQuicBidirectionalStream</a></code> is added to both the
           <code><a>RTCQuicTransport</a></code>'s <a>[[\QuicTransportReadableStreams]]</a>
           and <a>[[\QuicTransportWritableStreams]]</a> internal slot.</td>


### PR DESCRIPTION
The text explains that the events are fired when data is sent, so it's not necessary to include "withdata" within the event names or dictionaries.