### PR TITLE
Require server opt-in with transport parameters

### DIFF
--- a/cs.html
+++ b/cs.html
@@ -770,7 +770,7 @@ interface QuicTransport : QuicTransportBase {
                     <!-- TODO: register 0x333A with IANA -->
                 </li>
                 <li>
-                    Let <var>serialiedAcceptedOrigins</var> be
+                    Let <var>serializedAcceptedOrigins</var> be
                     <var>joinedAcceptedOrigins</var> split by the separator
                     <code>","</code>.
                 </li>

--- a/cs.html
+++ b/cs.html
@@ -752,29 +752,43 @@ interface QuicTransport : QuicTransportBase {
             </li>
             <li>Run these steps in parallel:
               <ol>
-                
-                <!-- TODO: Figure out a way to convey the origin in an encrypted manner
-                           and then use a non-empty value like so:
-                Let <var>serializedOrigin<var> be the empty string ,<code>""</code>.
-                Let <var>serializedOrigin<var> be <var>quictransport<var>'s 
-                <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s
-                <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>,
-                <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">serialized</a>.
-                The user agent MUST include a QUIC transport parameter with ID of web_origin(0x3330) 
-                and value of <var>serializedOrigin</var>.
-                -->
                 <li>Establish a QUIC connection to the address identified by the
-                <var>parsedUrl</var>'s host and port.  
-                During connection establishment, use of this API must be indicated 
-                by selecting the ALPN [[!ALPN]] token "wq" in the crypto handshake.
-                <!-- TODO: register "wq" with IANA. -->  
+                  <var>parsedUrl</var>'s host and port.  
+                  During connection establishment, use of this API must be indicated 
+                  by selecting the ALPN [[!ALPN]] token "wq" in the crypto handshake 
+                  and including a QUIC transport parameter with ID web_client(0x333C)
+                  and empty value.
+                  <!-- TODO: register "wq" with IANA. --> 
                 </li>
-                <li>If the connection succeeds, set
-                the <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
-                internal slot to <code>"connected"</code>.</li>
-                <li>If the connection fails, set
-                the <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
-                internal slot to <code>"failed"</code>.</li>
+                <li>If the connection fails, set <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
+                    internal slot to <code>"failed"</code> and abort these steps.
+                </li>
+                <li>Let <var>joinedAcceptedOrigins</var> be the QUIC transport parameter provided
+                    by the server with ID web_accepted_origins(0x333A).  If the transport parameter is
+                    absent, set <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
+                    internal slot to <code>"failed"</code> and abort these steps.
+                    <!-- TODO: register 0x333A with IANA -->
+                </li>
+                <li>
+                    Let <var>serialiedAcceptedOrigins</var> be
+                    <var>joinedAcceptedOrigins</var> split by the separator
+                    <code>","</code>.
+                </li>
+                <li>
+                    Let <var>serializedOrigin</var> be <var>quictransport</var>'s 
+                    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>'s
+                    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">origin</a>,
+                    <a href="https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin">serialized</a>.
+                </li>
+                <li>If <var>serializedOrigin</var> is a member of <var>serializedAcceptedOrigins</var> 
+                    or <var>joinedAcceptedOrigins</var> is equal to <code>"*"</code>, 
+                    set <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
+                    internal slot to <code>"connected"</code> and abort these steps.
+                </li>
+                <li>
+                    Set <var>quictransport</var>'s <a>[[\QuicTransportState]]</a>
+                    internal slot to <code>"failed"</code>.
+                </li>
               </ol>
             </li>
             <li>


### PR DESCRIPTION
- Send web client transport parameter web_client 0x333C
- Check that the client's origin is in the server's transport parameter web_accepted_origins 0x333A (or the transport parameter is "*").

An attempt at solving https://github.com/w3c/webrtc-quic/issues/97 with Victor's idea.